### PR TITLE
Add API to search songs

### DIFF
--- a/pages/api/search.js
+++ b/pages/api/search.js
@@ -1,0 +1,27 @@
+import { api_link } from '@/lib/api';
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    const { query } = req.query;
+
+    if (!query) {
+      return res.status(400).json({ error: 'Query parameter is required' });
+    }
+
+    try {
+      const response = await fetch(`${api_link}/search/all?query=${query}`);
+      const data = await response.json();
+
+      if (data.data) {
+        return res.status(200).json(data.data);
+      } else {
+        return res.status(404).json({ error: 'No results found' });
+      }
+    } catch (error) {
+      console.error('Error fetching search results:', error);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  } else {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+}


### PR DESCRIPTION
Add API to search songs.

* Create a new file `pages/api/search.js` to handle the GET request at `/api/search`.
* Define a handler function to process the GET request.
* Use the `fetch` function to call the external API with the search query parameter.
* Return the search results as a JSON response.
* Handle errors and return appropriate status codes for missing query parameters, no results found, and internal server errors.
* Restrict the handler to only allow GET requests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nandan-varma/songs/pull/1?shareId=3ccf520c-fae3-48a3-8a6f-eea626f0f6f4).