### PR TITLE
refactor: improve TypeScript types and add test fixtures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,20 +43,19 @@ It is based on the current repository state, scripts, and conventions in this co
 
 ## Test Commands
 
-- There is currently no test runner configured.
-- No `*.test.*` or `*.spec.*` files exist in the repo at the time of writing.
-- There is no supported "single test" command yet because there are no tests.
-- If you need targeted verification today, use:
-  - single-file lint: `npx biome check path/to/file.tsx`
-  - full verification: `npm run build`
-- If you introduce a test framework later, add package scripts and update this file.
+- Run tests: `npm run test`
+- Run tests with coverage: `npm run test:coverage`
+- Run in watch mode: `npm run test -- --watch`
+- No dedicated "single test" command exists; use vitest's file filtering
+- Test files are in `__tests__/` directory
+- Use `npm run build` as the authoritative verification for non-trivial changes
 
 ## Verification Expectations
 
 - For small isolated edits: run targeted `biome check` on touched files.
 - For cross-cutting or architectural edits: run `npm run lint` and `npm run build`.
 - If dependencies change: run `pnpm install` to sync the lockfile.
-- Do not claim tests passed; there are no automated tests configured.
+- After test changes: run `npm run test` to verify.
 
 ## General Code Style
 
@@ -94,16 +93,18 @@ It is based on the current repository state, scripts, and conventions in this co
 ## React And Next.js Conventions
 
 - Add `"use client";` only when a file truly needs client-side hooks or browser APIs.
+- All hook files in `hooks/` require `"use client";` - don't forget this directive.
 - Prefer server-compatible modules by default.
 - Route files may use default exports; elsewhere prefer named exports.
 - Keep page components thin and move repeated logic into shared components or hooks.
 - Current entity pages intentionally still use query params like `/song?id=...`.
 - Do not migrate to dynamic route segments unless explicitly requested.
+- Wrap top-level client components with `ErrorBoundary` from `@/components/common/error-boundary`.
 
 ## State Management
 
 - The public Zustand interface lives in `hooks/use-store.ts`.
-- Store implementation is split under `lib/store/`.
+- Store implementation is split under `lib/store/` with slices in `lib/store/slices/`.
 - When changing store behavior, preserve the public API unless there is a clear reason to change it.
 - Prefer adding behavior inside the appropriate slice:
   - playback / queue
@@ -111,6 +112,8 @@ It is based on the current repository state, scripts, and conventions in this co
   - playlists
   - downloads / UI
 - Keep persisted state compatible with `PersistedAppStoreState` unless intentionally changing storage shape.
+- Slice functions use `set as never` type assertion - this is intentional for TypeScript compatibility.
+- Return values from store hooks should be memoized with `useMemo` to prevent unnecessary re-renders.
 
 ## React Query Conventions
 
@@ -179,4 +182,5 @@ It is based on the current repository state, scripts, and conventions in this co
 - Ensure imports are clean.
 - Ensure Biome passes.
 - Ensure `npm run build` passes for non-trivial changes.
-- Mention clearly if verification was limited because no automated tests exist.
+- Run `npm run test` if tests exist.
+- Mention clearly if verification was limited.

--- a/__tests__/fixtures/index.ts
+++ b/__tests__/fixtures/index.ts
@@ -1,0 +1,236 @@
+import {
+	ArtistRole,
+	AudioQuality,
+	EntityType,
+	ImageQuality,
+} from "@/types/entity";
+import type {
+	AlbumMini,
+	ArtistMini,
+	DetailedAlbum,
+	DetailedArtist,
+	DetailedPlaylist,
+	DetailedSong,
+	DownloadUrl,
+	Image,
+	Language,
+	LocalPlaylist,
+} from "@/types/entity";
+
+const DEFAULT_IMAGE: Image = {
+	quality: ImageQuality.MEDIUM,
+	url: "https://example.com/image.jpg",
+};
+
+const DEFAULT_DOWNLOAD_URL: DownloadUrl = {
+	quality: AudioQuality.HIGH,
+	url: "https://example.com/audio.mp3",
+};
+
+const _DEFAULT_ARTIST: ArtistMini = {
+	id: "artist1",
+	name: "Test Artist",
+	role: ArtistRole.PRIMARY,
+	type: EntityType.ARTIST,
+	image: [DEFAULT_IMAGE],
+	url: "https://example.com/artist",
+};
+
+const _DEFAULT_ALBUM_MINI: AlbumMini = {
+	id: "album1",
+	name: "Test Album",
+	url: "https://example.com/album",
+};
+
+export interface SongOverrides {
+	id?: string;
+	name?: string;
+	year?: string | null;
+	releaseDate?: string | null;
+	duration?: number | null;
+	language?: Language | string;
+	image?: Image[];
+	downloadUrl?: DownloadUrl[];
+	artists?: {
+		primary: ArtistMini[];
+		featured: ArtistMini[];
+		all: ArtistMini[];
+	};
+	album?: AlbumMini;
+}
+
+export function createImage(overrides: Partial<Image> = {}): Image {
+	return {
+		quality: ImageQuality.MEDIUM,
+		url: "https://example.com/image.jpg",
+		...overrides,
+	};
+}
+
+export function createDownloadUrl(
+	overrides: Partial<DownloadUrl> = {},
+): DownloadUrl {
+	return {
+		quality: AudioQuality.HIGH,
+		url: "https://example.com/audio.mp3",
+		...overrides,
+	};
+}
+
+export function createArtistMini(
+	overrides: Partial<ArtistMini> = {},
+): ArtistMini {
+	return {
+		id: "artist1",
+		name: "Test Artist",
+		role: ArtistRole.PRIMARY,
+		type: EntityType.ARTIST,
+		image: [DEFAULT_IMAGE],
+		url: "https://example.com/artist",
+		...overrides,
+	};
+}
+
+export function createAlbumMini(overrides: Partial<AlbumMini> = {}): AlbumMini {
+	return {
+		id: "album1",
+		name: "Test Album",
+		url: "https://example.com/album",
+		...overrides,
+	};
+}
+
+export function createDetailedSong(
+	overrides: SongOverrides = {},
+): DetailedSong {
+	const id = overrides.id ?? "song1";
+	return {
+		id,
+		name: overrides.name ?? "Test Song",
+		type: EntityType.SONG,
+		year: overrides.year ?? "2024",
+		releaseDate: overrides.releaseDate ?? "2024-01-01",
+		duration: overrides.duration ?? 180,
+		label: "Test Label",
+		explicitContent: false,
+		playCount: 1000,
+		language: overrides.language ?? Language.HINDI,
+		hasLyrics: true,
+		lyricsId: "lyrics1",
+		url: `https://example.com/song/${id}`,
+		copyright: "2024 Test",
+		album: overrides.album ?? createAlbumMini(),
+		artists: overrides.artists ?? {
+			primary: [createArtistMini({ name: "Primary Artist" })],
+			featured: [],
+			all: [createArtistMini({ name: "Primary Artist" })],
+		},
+		image: overrides.image ?? [DEFAULT_IMAGE],
+		downloadUrl: overrides.downloadUrl ?? [DEFAULT_DOWNLOAD_URL],
+	};
+}
+
+export function createDetailedAlbum(
+	overrides: Partial<Omit<DetailedAlbum, "songs">> & {
+		songs?: DetailedSong[];
+	} = {},
+): DetailedAlbum {
+	const id = overrides.id ?? "album1";
+	return {
+		id,
+		name: overrides.name ?? "Test Album",
+		description: "Test album description",
+		year: 2024,
+		type: EntityType.ALBUM,
+		playCount: 5000,
+		language: Language.HINDI,
+		explicitContent: false,
+		artists: {
+			primary: [createArtistMini({ name: "Album Artist" })],
+			featured: [],
+			all: [createArtistMini({ name: "Album Artist" })],
+		},
+		songCount: 10,
+		url: `https://example.com/album/${id}`,
+		image: [DEFAULT_IMAGE],
+		songs: overrides.songs ?? [],
+	};
+}
+
+export function createDetailedArtist(
+	overrides: Partial<DetailedArtist> = {},
+): DetailedArtist {
+	const id = overrides.id ?? "artist1";
+	return {
+		id,
+		name: "Test Artist",
+		url: `https://example.com/artist/${id}`,
+		type: EntityType.ARTIST,
+		image: [DEFAULT_IMAGE],
+		followerCount: 10000,
+		fanCount: "5000",
+		isVerified: true,
+		dominantLanguage: Language.HINDI,
+		dominantType: EntityType.SONG,
+		bio: null,
+		dob: null,
+		fb: "https://facebook.com/test",
+		twitter: "https://twitter.com/test",
+		wiki: "https://wikipedia.org/test",
+		availableLanguages: ["hindi", "english"],
+		isRadioPresent: true,
+		topSongs: null,
+		topAlbums: null,
+		singles: null,
+		similarArtists: null,
+		...overrides,
+	};
+}
+
+export function createDetailedPlaylist(
+	overrides: Partial<DetailedPlaylist> = {},
+): DetailedPlaylist {
+	const id = overrides.id ?? "playlist1";
+	return {
+		id,
+		name: "Test Playlist",
+		description: "Test playlist description",
+		year: 2024,
+		type: EntityType.PLAYLIST,
+		playCount: 1000,
+		language: Language.HINDI,
+		explicitContent: false,
+		songCount: 5,
+		url: `https://example.com/playlist/${id}`,
+		image: [DEFAULT_IMAGE],
+		songs: [],
+		artists: [createArtistMini()],
+		...overrides,
+	};
+}
+
+export function createLocalPlaylist(
+	overrides: Partial<Omit<LocalPlaylist, "songs">> & {
+		songs?: DetailedSong[];
+	} = {},
+): LocalPlaylist {
+	const id = overrides.id ?? "local1";
+	const now = Date.now();
+	return {
+		id,
+		name: "My Playlist",
+		songs: overrides.songs ?? [],
+		createdAt: overrides.createdAt ?? now,
+		updatedAt: overrides.updatedAt ?? now,
+		...overrides,
+	};
+}
+
+export const TEST_SONG = createDetailedSong();
+export const TEST_SONG_2 = createDetailedSong({
+	id: "song2",
+	name: "Second Song",
+});
+export const TEST_ALBUM = createDetailedAlbum();
+export const TEST_ARTIST = createDetailedArtist();
+export const TEST_PLAYLIST = createDetailedPlaylist();

--- a/__tests__/fixtures/store.ts
+++ b/__tests__/fixtures/store.ts
@@ -1,0 +1,108 @@
+import { vi } from "vitest";
+import type { AppStoreState, RepeatMode } from "@/lib/store/types";
+import type { DetailedSong, EntityVisit, LocalPlaylist } from "@/types/entity";
+
+type PartialState = Partial<AppStoreState>;
+
+function createMockState(overrides: PartialState = {}): AppStoreState {
+	return {
+		currentSong: null,
+		isPlaying: false,
+		currentTime: 0,
+		duration: 0,
+		volume: 0.7,
+		playbackSpeed: 1,
+		isMuted: false,
+		queue: [],
+		queueIndex: 0,
+		isShuffleEnabled: false,
+		repeatMode: "off" as RepeatMode,
+		favoriteIds: new Set<string>(),
+		searchHistory: [],
+		playbackHistory: [],
+		visitHistory: [],
+		maxHistorySize: 100,
+		playlists: [],
+		isQueueOpen: false,
+		downloadedSongIds: new Set<string>(),
+		sleepTimerMinutes: null,
+		...overrides,
+	};
+}
+
+export interface MockStoreOptions {
+	initialState?: PartialState;
+	songs?: DetailedSong[];
+	queue?: DetailedSong[];
+	favoriteIds?: string[];
+	searchHistory?: string[];
+	playbackHistory?: DetailedSong[];
+	visitHistory?: EntityVisit[];
+	playlists?: LocalPlaylist[];
+	downloadedSongIds?: string[];
+}
+
+export function createMockStore(options: MockStoreOptions = {}) {
+	const {
+		initialState,
+		queue = [],
+		favoriteIds = [],
+		searchHistory = [],
+		playbackHistory = [],
+		visitHistory = [],
+		playlists = [],
+		downloadedSongIds = [],
+	} = options;
+
+	const state = createMockState({
+		...initialState,
+		queue,
+		favoriteIds: new Set(favoriteIds),
+		searchHistory,
+		playbackHistory,
+		visitHistory,
+		playlists,
+		downloadedSongIds: new Set(downloadedSongIds),
+	});
+
+	const mockGet = vi.fn(() => state);
+	const mockSet = vi.fn(
+		(
+			updater:
+				| Partial<AppStoreState>
+				| ((prev: AppStoreState) => Partial<AppStoreState>),
+		) => {
+			if (typeof updater === "function") {
+				const updates = updater(state);
+				Object.assign(state, updates);
+			} else {
+				Object.assign(state, updater);
+			}
+		},
+	);
+
+	return {
+		get: mockGet,
+		set: mockSet,
+		state,
+	};
+}
+
+export type MockStore = ReturnType<typeof createMockStore>;
+
+export function createMockSetGetter() {
+	const set = vi.fn();
+	const get = vi.fn();
+	return {
+		set: set as AppStoreState extends Record<string, unknown>
+			? (
+					state:
+						| Partial<AppStoreState>
+						| ((prev: AppStoreState) => Partial<AppStoreState>),
+				) => void
+			: never,
+		get,
+	};
+}
+
+export { createMockState, vi };

--- a/__tests__/lib/constants.test.ts
+++ b/__tests__/lib/constants.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { feature_flags, isValidRoute, VALID_ROUTES } from "@/lib/constants";
+
+describe("VALID_ROUTES", () => {
+	it("contains expected routes", () => {
+		expect(VALID_ROUTES).toContain("/");
+		expect(VALID_ROUTES).toContain("/library");
+		expect(VALID_ROUTES).toContain("/downloads");
+		expect(VALID_ROUTES).toContain("/favorites");
+	});
+});
+
+describe("isValidRoute", () => {
+	it("returns true for valid routes", () => {
+		expect(isValidRoute("/")).toBe(true);
+		expect(isValidRoute("/library")).toBe(true);
+		expect(isValidRoute("/downloads")).toBe(true);
+		expect(isValidRoute("/favorites")).toBe(true);
+	});
+
+	it("returns false for invalid routes", () => {
+		expect(isValidRoute("/invalid")).toBe(false);
+		expect(isValidRoute("/foo")).toBe(false);
+		expect(isValidRoute("/library/foo")).toBe(false);
+	});
+
+	it("returns false for non-strings", () => {
+		expect(isValidRoute(null)).toBe(false);
+		expect(isValidRoute(undefined)).toBe(false);
+		expect(isValidRoute(123)).toBe(false);
+		expect(isValidRoute({})).toBe(false);
+		expect(isValidRoute([])).toBe(false);
+	});
+
+	it("returns false for empty string", () => {
+		expect(isValidRoute("")).toBe(false);
+	});
+});
+
+describe("feature_flags", () => {
+	it("has expected structure", () => {
+		expect(feature_flags).toHaveProperty("Artist_page_singles_enabled");
+	});
+
+	it("has expected default values", () => {
+		expect(feature_flags.Artist_page_singles_enabled).toBe(false);
+	});
+});

--- a/__tests__/lib/deployment.test.ts
+++ b/__tests__/lib/deployment.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { type BuildInfo, formatBuildInfo } from "@/lib/deployment";
+
+describe("formatBuildInfo", () => {
+	it("formats build info with version and timestamp", () => {
+		const buildInfo: BuildInfo = {
+			id: "abc123",
+			timestamp: 1704067200000, // 2024-01-01
+			version: "1.0.0",
+			git: {},
+			env: "production",
+		};
+		const result = formatBuildInfo(buildInfo);
+		expect(result).toContain("v1.0.0");
+	});
+
+	it("includes commit hash when present", () => {
+		const buildInfo: BuildInfo = {
+			id: "abc123",
+			timestamp: 1704067200000,
+			version: "1.0.0",
+			git: { commit: "abc123def" },
+			env: "production",
+		};
+		const result = formatBuildInfo(buildInfo);
+		expect(result).toContain("abc123def");
+	});
+
+	it("excludes commit when not present", () => {
+		const buildInfo: BuildInfo = {
+			id: "abc123",
+			timestamp: 1704067200000,
+			version: "1.0.0",
+			git: {},
+			env: "production",
+		};
+		const result = formatBuildInfo(buildInfo);
+		expect(result).not.toContain("commit");
+	});
+
+	it("handles zero timestamp", () => {
+		const buildInfo: BuildInfo = {
+			id: "abc123",
+			timestamp: 0,
+			version: "0.0.0",
+			git: {},
+			env: "development",
+		};
+		const result = formatBuildInfo(buildInfo);
+		expect(result).toContain("v0.0.0");
+	});
+});

--- a/__tests__/lib/store/internal.test.ts
+++ b/__tests__/lib/store/internal.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import {
+	clampPlaybackSpeed,
+	clampVolume,
+	createPlaylistId,
+	dedupeByEntity,
+	dedupeById,
+	dedupeStrings,
+	moveItem,
+	shuffleQueue,
+} from "@/lib/store/internal";
+import type { DetailedSong } from "@/types/entity";
+
+function makeSong(id: string): DetailedSong {
+	return { id, name: `Song ${id}`, type: "song" } as unknown as DetailedSong;
+}
+
+describe("clampVolume", () => {
+	it("returns volume within range", () => {
+		expect(clampVolume(0.5)).toBe(0.5);
+	});
+
+	it("clamps below 0 to 0", () => {
+		expect(clampVolume(-0.5)).toBe(0);
+		expect(clampVolume(-10)).toBe(0);
+	});
+
+	it("clamps above 1 to 1", () => {
+		expect(clampVolume(1.5)).toBe(1);
+		expect(clampVolume(100)).toBe(1);
+	});
+
+	it("handles boundary values", () => {
+		expect(clampVolume(0)).toBe(0);
+		expect(clampVolume(1)).toBe(1);
+	});
+});
+
+describe("clampPlaybackSpeed", () => {
+	it("returns speed within range", () => {
+		expect(clampPlaybackSpeed(1)).toBe(1);
+		expect(clampPlaybackSpeed(1.5)).toBe(1.5);
+	});
+
+	it("clamps below 0.25 to 0.25", () => {
+		expect(clampPlaybackSpeed(0)).toBe(0.25);
+		expect(clampPlaybackSpeed(-1)).toBe(0.25);
+	});
+
+	it("clamps above 2 to 2", () => {
+		expect(clampPlaybackSpeed(3)).toBe(2);
+		expect(clampPlaybackSpeed(10)).toBe(2);
+	});
+
+	it("handles boundary values", () => {
+		expect(clampPlaybackSpeed(0.25)).toBe(0.25);
+		expect(clampPlaybackSpeed(2)).toBe(2);
+	});
+});
+
+describe("createPlaylistId", () => {
+	it("generates ID with playlist_ prefix", () => {
+		const id = createPlaylistId();
+		expect(id.startsWith("playlist_")).toBe(true);
+	});
+
+	it("generates unique IDs", () => {
+		const id1 = createPlaylistId();
+		const id2 = createPlaylistId();
+		expect(id1).not.toBe(id2);
+	});
+});
+
+describe("dedupeStrings", () => {
+	it("adds new item to front", () => {
+		const result = dedupeStrings(["b", "c"], "a", 10);
+		expect(result).toEqual(["a", "b", "c"]);
+	});
+
+	it("moves existing item to front", () => {
+		const result = dedupeStrings(["a", "b", "c"], "b", 10);
+		expect(result).toEqual(["b", "a", "c"]);
+	});
+
+	it("respects max size", () => {
+		const result = dedupeStrings(["a", "b", "c"], "d", 3);
+		expect(result).toEqual(["d", "a", "b"]);
+	});
+
+	it("handles empty array", () => {
+		const result = dedupeStrings([], "a", 5);
+		expect(result).toEqual(["a"]);
+	});
+
+	it("handles max size of 1", () => {
+		const result = dedupeStrings(["a", "b"], "c", 1);
+		expect(result).toEqual(["c"]);
+	});
+});
+
+describe("dedupeById", () => {
+	it("adds new item to front", () => {
+		const items = [{ id: "b" }, { id: "c" }];
+		const result = dedupeById(items, { id: "a" }, 10);
+		expect(result.map((i) => i.id)).toEqual(["a", "b", "c"]);
+	});
+
+	it("moves existing item to front", () => {
+		const items = [{ id: "a" }, { id: "b" }, { id: "c" }];
+		const result = dedupeById(items, { id: "b" }, 10);
+		expect(result.map((i) => i.id)).toEqual(["b", "a", "c"]);
+	});
+
+	it("respects max size", () => {
+		const items = [{ id: "a" }, { id: "b" }, { id: "c" }];
+		const result = dedupeById(items, { id: "d" }, 3);
+		expect(result.map((i) => i.id)).toEqual(["d", "a", "b"]);
+	});
+});
+
+describe("dedupeByEntity", () => {
+	it("adds new item to front", () => {
+		const items = [{ entityId: "b" }, { entityId: "c" }];
+		const result = dedupeByEntity(items, { entityId: "a" }, 10);
+		expect(result.map((i) => i.entityId)).toEqual(["a", "b", "c"]);
+	});
+
+	it("moves existing item to front", () => {
+		const items = [{ entityId: "a" }, { entityId: "b" }];
+		const result = dedupeByEntity(items, { entityId: "b" }, 10);
+		expect(result.map((i) => i.entityId)).toEqual(["b", "a"]);
+	});
+
+	it("respects max size", () => {
+		const items = [{ entityId: "a" }, { entityId: "b" }];
+		const result = dedupeByEntity(items, { entityId: "c" }, 2);
+		expect(result.map((i) => i.entityId)).toEqual(["c", "a"]);
+	});
+});
+
+describe("moveItem", () => {
+	it("moves item forward", () => {
+		const result = moveItem(["a", "b", "c", "d"], 0, 2);
+		expect(result).toEqual(["b", "c", "a", "d"]);
+	});
+
+	it("moves item backward", () => {
+		const result = moveItem(["a", "b", "c", "d"], 3, 1);
+		expect(result).toEqual(["a", "d", "b", "c"]);
+	});
+
+	it("returns unchanged array for invalid fromIndex", () => {
+		const items = ["a", "b", "c"];
+		const result = moveItem(items, 10, 0);
+		expect(result).toBe(items);
+	});
+
+	it("handles moving to same position", () => {
+		const result = moveItem(["a", "b", "c"], 1, 1);
+		expect(result).toEqual(["a", "b", "c"]);
+	});
+
+	it("handles single item array", () => {
+		const result = moveItem(["a"], 0, 0);
+		expect(result).toEqual(["a"]);
+	});
+
+	it("handles empty array", () => {
+		const result = moveItem([], 0, 0);
+		expect(result).toEqual([]);
+	});
+});
+
+describe("shuffleQueue", () => {
+	it("returns same queue for empty array", () => {
+		const result = shuffleQueue([], 0);
+		expect(result.queue).toEqual([]);
+		expect(result.queueIndex).toBe(0);
+	});
+
+	it("returns same queue for single item", () => {
+		const songs = [makeSong("a")];
+		const result = shuffleQueue(songs, 0);
+		expect(result.queue).toEqual(songs);
+		expect(result.queueIndex).toBe(0);
+	});
+
+	it("places current song at index 0", () => {
+		const songs = [makeSong("a"), makeSong("b"), makeSong("c")];
+		const result = shuffleQueue(songs, 1);
+		expect(result.queue[0]?.id).toBe("b");
+		expect(result.queueIndex).toBe(0);
+	});
+
+	it("includes all songs in shuffled queue", () => {
+		const songs = [makeSong("a"), makeSong("b"), makeSong("c"), makeSong("d")];
+		const result = shuffleQueue(songs, 0);
+		const ids = result.queue.map((s) => s.id).sort();
+		expect(ids).toEqual(["a", "b", "c", "d"]);
+	});
+
+	it("handles current index at end", () => {
+		const songs = [makeSong("a"), makeSong("b"), makeSong("c")];
+		const result = shuffleQueue(songs, 2);
+		expect(result.queue[0]?.id).toBe("c");
+		expect(result.queue.length).toBe(3);
+	});
+
+	it("handles current index out of bounds by duplicating first song", () => {
+		const songs = [makeSong("a"), makeSong("b")];
+		const result = shuffleQueue(songs, 10);
+		expect(result.queue.length).toBe(3);
+		expect(result.queue[0]?.id).toBe("a");
+		expect(result.queueIndex).toBe(0);
+	});
+});

--- a/__tests__/lib/store/slices/downloads-slice.test.ts
+++ b/__tests__/lib/store/slices/downloads-slice.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDownloadsAndUiSlice } from "@/lib/store/slices/downloads-slice";
+import type { RepeatMode } from "@/lib/store/types";
+import type { DetailedSong, LocalPlaylist } from "@/types/entity";
+
+function makeState(
+	overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+	return {
+		currentSong: null as DetailedSong | null,
+		isPlaying: false,
+		currentTime: 0,
+		duration: 0,
+		volume: 0.7,
+		playbackSpeed: 1,
+		isMuted: false,
+		queue: [] as DetailedSong[],
+		queueIndex: 0,
+		isShuffleEnabled: false,
+		repeatMode: "off" as RepeatMode,
+		favoriteIds: new Set<string>(),
+		searchHistory: [] as string[],
+		playbackHistory: [] as DetailedSong[],
+		visitHistory: [] as { entityId: string; entityType: string }[],
+		maxHistorySize: 100,
+		playlists: [] as LocalPlaylist[],
+		isQueueOpen: false,
+		downloadedSongIds: new Set<string>(),
+		sleepTimerMinutes: null as number | null,
+		...overrides,
+	};
+}
+
+describe("downloads-slice", () => {
+	let set: ReturnType<typeof vi.fn>;
+	let get: ReturnType<typeof vi.fn>;
+	let actions: ReturnType<typeof createDownloadsAndUiSlice>;
+
+	beforeEach(() => {
+		set = vi.fn();
+		get = vi.fn();
+		actions = createDownloadsAndUiSlice(set as never, get as never);
+	});
+
+	describe("setIsQueueOpen", () => {
+		it("sets isQueueOpen to true", () => {
+			actions.setIsQueueOpen(true);
+			expect(set).toHaveBeenCalledWith({ isQueueOpen: true });
+		});
+	});
+
+	describe("setSleepTimer", () => {
+		it("sets sleep timer minutes", () => {
+			actions.setSleepTimer(30);
+			expect(set).toHaveBeenCalledWith({ sleepTimerMinutes: 30 });
+		});
+
+		it("can clear sleep timer", () => {
+			actions.setSleepTimer(null);
+			expect(set).toHaveBeenCalledWith({ sleepTimerMinutes: null });
+		});
+	});
+
+	describe("addDownloadedSong", () => {
+		it("adds song to downloaded set", () => {
+			actions.addDownloadedSong("song1");
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("removeDownloadedSong", () => {
+		it("removes song from downloaded set", () => {
+			actions.removeDownloadedSong("song1");
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("syncDownloadedSongs", () => {
+		it("replaces downloaded song ids", () => {
+			actions.syncDownloadedSongs(["song1", "song2"]);
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("clearDownloadedSongs", () => {
+		it("clears all downloaded songs", () => {
+			actions.clearDownloadedSongs();
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("isDownloaded", () => {
+		it("returns true for downloaded song", () => {
+			get.mockReturnValue(makeState({ downloadedSongIds: new Set(["song1"]) }));
+			expect(actions.isDownloaded("song1")).toBe(true);
+		});
+
+		it("returns false for non-downloaded song", () => {
+			get.mockReturnValue(makeState({ downloadedSongIds: new Set() }));
+			expect(actions.isDownloaded("song1")).toBe(false);
+		});
+	});
+
+	describe("resetStore", () => {
+		it("resets to initial state", () => {
+			actions.resetStore();
+			expect(set).toHaveBeenCalled();
+		});
+	});
+});

--- a/__tests__/lib/store/slices/library-slice.test.ts
+++ b/__tests__/lib/store/slices/library-slice.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLibrarySlice } from "@/lib/store/slices/library-slice";
+import type { RepeatMode } from "@/lib/store/types";
+import {
+	type DetailedSong,
+	EntityType,
+	type EntityVisit,
+	type LocalPlaylist,
+} from "@/types/entity";
+
+function makeSong(id: string): DetailedSong {
+	return {
+		id,
+		name: `Song ${id}`,
+		type: "song",
+		year: "2024",
+		releaseDate: "2024-01-01",
+		duration: 180,
+		label: "Test",
+		explicitContent: false,
+		playCount: 100,
+		language: "hindi",
+		hasLyrics: false,
+		lyricsId: null,
+		url: `https://example.com/${id}`,
+		copyright: "2024",
+		album: { id: "album1", name: "Album", url: "https://example.com/album" },
+		artists: { primary: [], featured: [], all: [] },
+		image: [],
+		downloadUrl: [],
+	} as unknown as DetailedSong;
+}
+
+function makeState(
+	overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+	return {
+		currentSong: null as DetailedSong | null,
+		isPlaying: false,
+		currentTime: 0,
+		duration: 0,
+		volume: 0.7,
+		playbackSpeed: 1,
+		isMuted: false,
+		queue: [] as DetailedSong[],
+		queueIndex: 0,
+		isShuffleEnabled: false,
+		repeatMode: "off" as RepeatMode,
+		favoriteIds: new Set<string>(),
+		searchHistory: [] as string[],
+		playbackHistory: [] as DetailedSong[],
+		visitHistory: [] as EntityVisit[],
+		maxHistorySize: 100,
+		playlists: [] as LocalPlaylist[],
+		isQueueOpen: false,
+		downloadedSongIds: new Set<string>(),
+		sleepTimerMinutes: null as number | null,
+		...overrides,
+	};
+}
+
+describe("library-slice", () => {
+	let set: ReturnType<typeof vi.fn>;
+	let get: ReturnType<typeof vi.fn>;
+	let actions: ReturnType<typeof createLibrarySlice>;
+
+	beforeEach(() => {
+		set = vi.fn();
+		get = vi.fn();
+		actions = createLibrarySlice(set as never, get as never);
+	});
+
+	describe("toggleFavorite", () => {
+		it("toggles favorite", () => {
+			get.mockReturnValue(makeState({ favoriteIds: new Set() }));
+			actions.toggleFavorite("song1");
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("isFavorite", () => {
+		it("returns true when favorited", () => {
+			get.mockReturnValue(makeState({ favoriteIds: new Set(["song1"]) }));
+			expect(actions.isFavorite("song1")).toBe(true);
+		});
+
+		it("returns false when not favorited", () => {
+			get.mockReturnValue(makeState({ favoriteIds: new Set() }));
+			expect(actions.isFavorite("song1")).toBe(false);
+		});
+	});
+
+	describe("addFavorite", () => {
+		it("adds favorite", () => {
+			actions.addFavorite("song1");
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("removeFavorite", () => {
+		it("removes favorite", () => {
+			actions.removeFavorite("song1");
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("addToSearchHistory", () => {
+		it("adds query to search history", () => {
+			get.mockReturnValue(makeState({ searchHistory: [], maxHistorySize: 10 }));
+			actions.addToSearchHistory("test query");
+			expect(set).toHaveBeenCalled();
+		});
+
+		it("does nothing for empty query", () => {
+			get.mockReturnValue(makeState({ searchHistory: ["test"] }));
+			actions.addToSearchHistory("   ");
+			expect(set).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("clearSearchHistory", () => {
+		it("clears search history", () => {
+			actions.clearSearchHistory();
+			expect(set).toHaveBeenCalledWith({ searchHistory: [] });
+		});
+	});
+
+	describe("addToPlaybackHistory", () => {
+		it("adds song to playback history", () => {
+			const song = makeSong("1");
+			get.mockReturnValue(
+				makeState({ playbackHistory: [], maxHistorySize: 10 }),
+			);
+			actions.addToPlaybackHistory(song);
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("clearPlaybackHistory", () => {
+		it("clears playback history", () => {
+			actions.clearPlaybackHistory();
+			expect(set).toHaveBeenCalledWith({ playbackHistory: [] });
+		});
+	});
+
+	describe("addToVisitHistory", () => {
+		it("adds visit to history", () => {
+			const visit: EntityVisit = {
+				entityId: "song1",
+				entityType: EntityType.SONG,
+				entityName: "Test Song",
+				image: [],
+				timestamp: Date.now(),
+			};
+			get.mockReturnValue(makeState({ visitHistory: [], maxHistorySize: 10 }));
+			actions.addToVisitHistory(visit);
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("clearVisitHistory", () => {
+		it("clears visit history", () => {
+			actions.clearVisitHistory();
+			expect(set).toHaveBeenCalledWith({ visitHistory: [] });
+		});
+	});
+});

--- a/__tests__/lib/store/slices/playback-slice.test.ts
+++ b/__tests__/lib/store/slices/playback-slice.test.ts
@@ -1,0 +1,327 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPlaybackSlice } from "@/lib/store/slices/playback-slice";
+import type { RepeatMode } from "@/lib/store/types";
+import type { DetailedSong, LocalPlaylist } from "@/types/entity";
+
+function makeSong(id: string): DetailedSong {
+	return {
+		id,
+		name: `Song ${id}`,
+		type: "song",
+		year: "2024",
+		releaseDate: "2024-01-01",
+		duration: 180,
+		label: "Test",
+		explicitContent: false,
+		playCount: 100,
+		language: "hindi",
+		hasLyrics: false,
+		lyricsId: null,
+		url: `https://example.com/${id}`,
+		copyright: "2024",
+		album: { id: "album1", name: "Album", url: "https://example.com/album" },
+		artists: { primary: [], featured: [], all: [] },
+		image: [],
+		downloadUrl: [],
+	} as unknown as DetailedSong;
+}
+
+function makeState(
+	overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+	return {
+		currentSong: null as DetailedSong | null,
+		isPlaying: false,
+		currentTime: 0,
+		duration: 0,
+		volume: 0.7,
+		playbackSpeed: 1,
+		isMuted: false,
+		queue: [] as DetailedSong[],
+		queueIndex: 0,
+		isShuffleEnabled: false,
+		repeatMode: "off" as RepeatMode,
+		favoriteIds: new Set<string>(),
+		searchHistory: [] as string[],
+		playbackHistory: [] as DetailedSong[],
+		visitHistory: [] as { entityId: string; entityType: string }[],
+		maxHistorySize: 100,
+		playlists: [] as LocalPlaylist[],
+		isQueueOpen: false,
+		downloadedSongIds: new Set<string>(),
+		sleepTimerMinutes: null as number | null,
+		...overrides,
+	};
+}
+
+describe("playback-slice", () => {
+	let set: ReturnType<typeof vi.fn>;
+	let get: ReturnType<typeof vi.fn>;
+	let actions: ReturnType<typeof createPlaybackSlice>;
+
+	beforeEach(() => {
+		set = vi.fn();
+		get = vi.fn();
+		actions = createPlaybackSlice(set as never, get as never);
+	});
+
+	describe("playSong", () => {
+		it("replaces queue with single song when replaceQueue=true", () => {
+			const song = makeSong("1");
+			actions.playSong(song, true);
+			expect(set).toHaveBeenCalled();
+		});
+
+		it("finds existing song in queue when replaceQueue=false", () => {
+			const song1 = makeSong("1");
+			const song2 = makeSong("2");
+			get.mockReturnValue(makeState({ queue: [song1, song2], queueIndex: 0 }));
+			actions.playSong(song2, false);
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("playQueue", () => {
+		it("sets queue with start index", () => {
+			const songs = [makeSong("1"), makeSong("2"), makeSong("3")];
+			actions.playQueue(songs, 1);
+			expect(set).toHaveBeenCalledWith(
+				expect.objectContaining({
+					queue: songs,
+					queueIndex: 1,
+				}),
+			);
+		});
+
+		it("handles empty songs array", () => {
+			actions.playQueue([], 0);
+			expect(set).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("togglePlayPause", () => {
+		it("toggles isPlaying", () => {
+			get.mockReturnValue(makeState({ isPlaying: false }));
+			actions.togglePlayPause();
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("playNext", () => {
+		it("returns empty state when queue is empty", () => {
+			get.mockReturnValue(makeState({ queue: [] }));
+			actions.playNext();
+			expect(set).toHaveBeenCalled();
+		});
+
+		it("restarts song when repeat mode is one", () => {
+			const song = makeSong("1");
+			get.mockReturnValue(
+				makeState({
+					queue: [song],
+					queueIndex: 0,
+					currentSong: song,
+					repeatMode: "one",
+				}),
+			);
+			actions.playNext();
+			expect(set).toHaveBeenCalled();
+		});
+
+		it("plays next song normally", () => {
+			const songs = [makeSong("1"), makeSong("2")];
+			get.mockReturnValue(
+				makeState({
+					queue: songs,
+					queueIndex: 0,
+					repeatMode: "off",
+				}),
+			);
+			actions.playNext();
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("playPrevious", () => {
+		it("restarts when currentTime > threshold", () => {
+			get.mockReturnValue(makeState({ currentTime: 5 }));
+			actions.playPrevious();
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("setSongTime", () => {
+		it("sets currentTime", () => {
+			actions.setSongTime(30);
+			expect(set).toHaveBeenCalledWith({ currentTime: 30 });
+		});
+	});
+
+	describe("setSongDuration", () => {
+		it("handles NaN", () => {
+			actions.setSongDuration(NaN);
+			expect(set).toHaveBeenCalledWith({ duration: 0 });
+		});
+	});
+
+	describe("setVolume", () => {
+		it("sets volume", () => {
+			actions.setVolume(0.5);
+			expect(set).toHaveBeenCalledWith({ volume: 0.5 });
+		});
+	});
+
+	describe("setPlaybackSpeed", () => {
+		it("sets playbackSpeed", () => {
+			actions.setPlaybackSpeed(1.5);
+			expect(set).toHaveBeenCalledWith({ playbackSpeed: 1.5 });
+		});
+	});
+
+	describe("setCurrentSong", () => {
+		it("sets currentSong", () => {
+			const song = makeSong("1");
+			actions.setCurrentSong(song);
+			expect(set).toHaveBeenCalledWith({ currentSong: song });
+		});
+	});
+
+	describe("setIsPlaying", () => {
+		it("sets isPlaying", () => {
+			actions.setIsPlaying(true);
+			expect(set).toHaveBeenCalledWith({ isPlaying: true });
+		});
+	});
+
+	describe("toggleMute", () => {
+		it("toggles isMuted", () => {
+			get.mockReturnValue(makeState({ isMuted: false }));
+			actions.toggleMute();
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("addSongToQueue", () => {
+		it("adds song to queue", () => {
+			const song = makeSong("1");
+			actions.addSongToQueue(song);
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("addSongsToQueue", () => {
+		it("adds multiple songs to queue", () => {
+			const songs = [makeSong("1"), makeSong("2")];
+			actions.addSongsToQueue(songs);
+			expect(set).toHaveBeenCalled();
+		});
+
+		it("does nothing for empty array", () => {
+			actions.addSongsToQueue([]);
+			expect(set).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("insertSongNext", () => {
+		it("inserts song at next position", () => {
+			const song1 = makeSong("1");
+			const song2 = makeSong("2");
+			get.mockReturnValue(
+				makeState({
+					queue: [song1],
+					queueIndex: 0,
+					currentSong: song1,
+				}),
+			);
+			actions.insertSongNext(song2);
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("removeSongFromQueue", () => {
+		it("removes song at valid index", () => {
+			const songs = [makeSong("1"), makeSong("2")];
+			get.mockReturnValue(
+				makeState({
+					queue: songs,
+					queueIndex: 0,
+				}),
+			);
+			actions.removeSongFromQueue(0);
+			expect(set).toHaveBeenCalled();
+		});
+
+		it("handles out of bounds index", () => {
+			const songs = [makeSong("1")];
+			get.mockReturnValue(
+				makeState({
+					queue: songs,
+					queueIndex: 0,
+				}),
+			);
+			actions.removeSongFromQueue(10);
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("clearQueue", () => {
+		it("clears all queue state", () => {
+			actions.clearQueue();
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("setQueueIndex", () => {
+		it("sets queue index within bounds", () => {
+			const songs = [makeSong("1"), makeSong("2")];
+			get.mockReturnValue(
+				makeState({
+					queue: songs,
+				}),
+			);
+			actions.setQueueIndex(1);
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("toggleShuffle", () => {
+		it("toggles shuffle", () => {
+			get.mockReturnValue(makeState({ isShuffleEnabled: false }));
+			actions.toggleShuffle();
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("setRepeatMode", () => {
+		it("sets repeat mode", () => {
+			actions.setRepeatMode("all");
+			expect(set).toHaveBeenCalledWith({ repeatMode: "all" });
+		});
+	});
+
+	describe("reorderQueue", () => {
+		it("reorders queue", () => {
+			const songs = [makeSong("1"), makeSong("2"), makeSong("3")];
+			get.mockReturnValue(
+				makeState({
+					queue: songs,
+					queueIndex: 1,
+				}),
+			);
+			actions.reorderQueue(0, 2);
+			expect(set).toHaveBeenCalled();
+		});
+
+		it("handles invalid indices", () => {
+			const songs = [makeSong("1"), makeSong("2")];
+			get.mockReturnValue(
+				makeState({
+					queue: songs,
+					queueIndex: 0,
+				}),
+			);
+			actions.reorderQueue(-1, 5);
+			expect(set).toHaveBeenCalled();
+		});
+	});
+});

--- a/__tests__/lib/store/slices/playlist-slice.test.ts
+++ b/__tests__/lib/store/slices/playlist-slice.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPlaylistSlice } from "@/lib/store/slices/playlist-slice";
+import type { DetailedSong } from "@/types/entity";
+
+function makeSong(id: string): DetailedSong {
+	return {
+		id,
+		name: `Song ${id}`,
+		type: "song",
+		year: "2024",
+		releaseDate: "2024-01-01",
+		duration: 180,
+		label: "Test",
+		explicitContent: false,
+		playCount: 100,
+		language: "hindi",
+		hasLyrics: false,
+		lyricsId: null,
+		url: `https://example.com/${id}`,
+		copyright: "2024",
+		album: { id: "album1", name: "Album", url: "https://example.com/album" },
+		artists: { primary: [], featured: [], all: [] },
+		image: [],
+		downloadUrl: [],
+	} as unknown as DetailedSong;
+}
+
+describe("playlist-slice", () => {
+	let set: ReturnType<typeof vi.fn>;
+	let actions: ReturnType<typeof createPlaylistSlice>;
+
+	beforeEach(() => {
+		set = vi.fn();
+		actions = createPlaylistSlice(set as never);
+	});
+
+	describe("createPlaylist", () => {
+		it("creates playlist with valid name", () => {
+			const result = actions.createPlaylist("My Playlist");
+			expect(result).toContain("playlist_");
+			expect(set).toHaveBeenCalled();
+		});
+
+		it("throws error for empty name", () => {
+			expect(() => actions.createPlaylist("")).toThrow(
+				"Playlist name is required",
+			);
+		});
+
+		it("throws error for whitespace-only name", () => {
+			expect(() => actions.createPlaylist("   ")).toThrow(
+				"Playlist name is required",
+			);
+		});
+	});
+
+	describe("updatePlaylist", () => {
+		it("updates playlist name", () => {
+			expect(() =>
+				actions.updatePlaylist("playlist1", "New Name"),
+			).not.toThrow();
+		});
+
+		it("throws error for empty name", () => {
+			expect(() => actions.updatePlaylist("playlist1", "")).toThrow(
+				"Playlist name is required",
+			);
+		});
+	});
+
+	describe("deletePlaylist", () => {
+		it("removes playlist", () => {
+			actions.deletePlaylist("playlist1");
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("addSongToPlaylist", () => {
+		it("adds song to playlist", () => {
+			const song = makeSong("1");
+			actions.addSongToPlaylist("playlist1", song);
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("removeSongFromPlaylist", () => {
+		it("removes song from playlist", () => {
+			actions.removeSongFromPlaylist("playlist1", "song1");
+			expect(set).toHaveBeenCalled();
+		});
+	});
+
+	describe("reorderPlaylistSongs", () => {
+		it("reorders songs", () => {
+			actions.reorderPlaylistSongs("playlist1", 0, 2);
+			expect(set).toHaveBeenCalled();
+		});
+
+		it("handles invalid indices", () => {
+			actions.reorderPlaylistSongs("playlist1", -1, 5);
+			expect(set).toHaveBeenCalled();
+		});
+	});
+});

--- a/__tests__/lib/utils.test.ts
+++ b/__tests__/lib/utils.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it } from "vitest";
+import {
+	detailedSongToSong,
+	getImageByQuality,
+	getImageUrl,
+	songToDetailedSong,
+} from "@/lib/utils";
+import type {
+	AudioQuality,
+	DetailedSong,
+	Image,
+	ImageQuality,
+	Song,
+} from "@/types/entity";
+
+function makeImage(quality: string, url: string): Image {
+	return { quality: quality as ImageQuality, url };
+}
+
+function makeDetailedSong(overrides?: Partial<DetailedSong>): DetailedSong {
+	return {
+		id: "song1",
+		name: "Test Song",
+		type: "song",
+		year: "2024",
+		releaseDate: "2024-01-01",
+		duration: 180,
+		label: "Test Label",
+		explicitContent: false,
+		playCount: 1000,
+		language: "hindi",
+		hasLyrics: true,
+		lyricsId: "lyrics1",
+		url: "https://example.com/song",
+		copyright: "2024 Test",
+		album: {
+			id: "album1",
+			name: "Test Album",
+			url: "https://example.com/album",
+		},
+		artists: {
+			primary: [
+				{
+					id: "artist1",
+					name: "Artist One",
+					role: "singer",
+					type: "artist",
+					image: [],
+					url: "https://example.com/artist1",
+				},
+			],
+			featured: [],
+			all: [
+				{
+					id: "artist1",
+					name: "Artist One",
+					role: "singer",
+					type: "artist",
+					image: [],
+					url: "https://example.com/artist1",
+				},
+			],
+		},
+		image: [makeImage("500x500", "https://example.com/image.jpg")],
+		downloadUrl: [
+			{
+				quality: "VERY_HIGH" as unknown as AudioQuality,
+				url: "https://example.com/download",
+			},
+		],
+		...overrides,
+	};
+}
+
+function makeSong(overrides?: Partial<Song>): Song {
+	return {
+		id: "song1",
+		title: "Test Song",
+		image: [makeImage("500x500", "https://example.com/image.jpg")],
+		album: "Test Album",
+		url: "https://example.com/song",
+		type: "song",
+		description: "Artist One",
+		primaryArtists: "Artist One",
+		singers: "Artist One",
+		language: "hindi",
+		...overrides,
+	};
+}
+
+describe("getImageByQuality", () => {
+	it("returns null for undefined images", () => {
+		expect(getImageByQuality(undefined, "high")).toBeNull();
+	});
+
+	it("returns null for empty array", () => {
+		expect(getImageByQuality([], "high")).toBeNull();
+	});
+
+	it("finds high quality image", () => {
+		const images = [
+			makeImage("150x150", "url_low"),
+			makeImage("500x500", "url_high"),
+		];
+		expect(getImageByQuality(images, "high")).toBe("url_high");
+	});
+
+	it("finds medium quality image", () => {
+		const images = [
+			makeImage("150x150", "url_low"),
+			makeImage("500x500", "url_high"),
+		];
+		expect(getImageByQuality(images, "medium")).toBe("url_low");
+	});
+
+	it("finds low quality image", () => {
+		const images = [
+			makeImage("150x150", "url_low"),
+			makeImage("500x500", "url_high"),
+		];
+		expect(getImageByQuality(images, "low")).toBe("url_low");
+	});
+
+	it("falls back to index when quality not found", () => {
+		const images = [{ quality: "unknown" as ImageQuality, url: "url_unknown" }];
+		expect(getImageByQuality(images, "high")).toBe("url_unknown");
+	});
+
+	it("falls back to first image when index out of range", () => {
+		const images = [{ quality: "unknown" as ImageQuality, url: "" }];
+		expect(getImageByQuality(images, "high")).toBeNull();
+	});
+
+	it("falls back to first image when no URL found", () => {
+		const images = [makeImage("150x150", "url_low")];
+		expect(getImageByQuality(images, "high")).toBe("url_low");
+	});
+
+	it("returns null when all images have empty URLs", () => {
+		const images = [makeImage("150x150", ""), makeImage("500x500", "")];
+		expect(getImageByQuality(images, "low")).toBeNull();
+	});
+});
+
+describe("getImageUrl", () => {
+	it("returns fallback for undefined images", () => {
+		expect(getImageUrl(undefined)).toBe(
+			"https://placehold.co/500x500.webp?text=No+Image",
+		);
+	});
+
+	it("returns fallback for empty array", () => {
+		expect(getImageUrl([])).toBe(
+			"https://placehold.co/500x500.webp?text=No+Image",
+		);
+	});
+
+	it("returns custom fallback", () => {
+		expect(getImageUrl([], "https://custom.com/fallback.jpg")).toBe(
+			"https://custom.com/fallback.jpg",
+		);
+	});
+
+	it("prefers high quality image", () => {
+		const images = [
+			makeImage("150x150", "url_low"),
+			makeImage("500x500", "url_high"),
+		];
+		expect(getImageUrl(images)).toBe("url_high");
+	});
+
+	it("falls back to first image when no high quality", () => {
+		const images = [
+			{ quality: "unknown" as ImageQuality, url: "url_first" },
+			{ quality: "unknown" as ImageQuality, url: "url_last" },
+		];
+		expect(getImageUrl(images)).toBe("url_first");
+	});
+
+	it("falls back to first image for single item", () => {
+		const images = [{ quality: "unknown" as ImageQuality, url: "url_only" }];
+		expect(getImageUrl(images)).toBe("url_only");
+	});
+
+	it("falls back to default when image has empty URL", () => {
+		const images = [{ quality: "unknown" as ImageQuality, url: "" }];
+		expect(getImageUrl(images)).toBe(
+			"https://placehold.co/500x500.webp?text=No+Image",
+		);
+	});
+});
+
+describe("detailedSongToSong", () => {
+	it("converts detailed song to song", () => {
+		const detailed = makeDetailedSong();
+		const result = detailedSongToSong(detailed);
+		expect(result.id).toBe("song1");
+		expect(result.title).toBe("Test Song");
+		expect(result.album).toBe("Test Album");
+		expect(result.url).toBe("https://example.com/song");
+		expect(result.type).toBe("song");
+		expect(result.language).toBe("hindi");
+	});
+
+	it("maps primary artists to description", () => {
+		const detailed = makeDetailedSong({
+			artists: {
+				primary: [
+					{
+						id: "a1",
+						name: "Artist One",
+						role: "singer",
+						type: "artist",
+						image: [],
+						url: "",
+					},
+					{
+						id: "a2",
+						name: "Artist Two",
+						role: "singer",
+						type: "artist",
+						image: [],
+						url: "",
+					},
+				],
+				featured: [],
+				all: [],
+			},
+		});
+		const result = detailedSongToSong(detailed);
+		expect(result.description).toBe("Artist One, Artist Two");
+		expect(result.primaryArtists).toBe("Artist One, Artist Two");
+	});
+
+	it("maps all artists to singers", () => {
+		const detailed = makeDetailedSong({
+			artists: {
+				primary: [],
+				featured: [],
+				all: [
+					{
+						id: "a1",
+						name: "Singer One",
+						role: "singer",
+						type: "artist",
+						image: [],
+						url: "",
+					},
+				],
+			},
+		});
+		const result = detailedSongToSong(detailed);
+		expect(result.singers).toBe("Singer One");
+	});
+
+	it("handles empty album name", () => {
+		const detailed = makeDetailedSong({
+			album: { id: null, name: "", url: null },
+		});
+		const result = detailedSongToSong(detailed);
+		expect(result.album).toBe("");
+	});
+
+	it("handles empty artists", () => {
+		const detailed = makeDetailedSong({
+			artists: { primary: [], featured: [], all: [] },
+		});
+		const result = detailedSongToSong(detailed);
+		expect(result.description).toBe("");
+		expect(result.primaryArtists).toBe("");
+		expect(result.singers).toBe("");
+	});
+});
+
+describe("songToDetailedSong", () => {
+	it("converts song to detailed song", () => {
+		const song = makeSong();
+		const result = songToDetailedSong(song);
+		expect(result.id).toBe("song1");
+		expect(result.name).toBe("Test Song");
+		expect(result.type).toBe("song");
+		expect(result.language).toBe("hindi");
+		expect(result.url).toBe("https://example.com/song");
+	});
+
+	it("sets defaults for missing fields", () => {
+		const song = {
+			id: "song1",
+			title: "Test",
+			image: [],
+			album: "",
+			url: "",
+			type: "song",
+			description: "",
+			primaryArtists: "",
+			singers: "",
+			language: "",
+		};
+		const result = songToDetailedSong(song);
+		expect(result.year).toBeNull();
+		expect(result.releaseDate).toBeNull();
+		expect(result.duration).toBeNull();
+		expect(result.label).toBeNull();
+		expect(result.explicitContent).toBe(false);
+		expect(result.playCount).toBeNull();
+		expect(result.hasLyrics).toBe(false);
+		expect(result.lyricsId).toBeNull();
+		expect(result.copyright).toBeNull();
+		expect(result.album).toEqual({ id: null, name: "", url: null });
+		expect(result.artists).toEqual({ primary: [], featured: [], all: [] });
+		expect(result.image).toEqual([]);
+		expect(result.downloadUrl).toEqual([]);
+	});
+
+	it("defaults type to 'song' when not provided", () => {
+		const song = makeSong({ type: undefined as unknown as string });
+		const result = songToDetailedSong(song);
+		expect(result.type).toBe("song");
+	});
+});

--- a/__tests__/lib/utils/audio-error.test.ts
+++ b/__tests__/lib/utils/audio-error.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	createErrorHandler,
+	getAudioErrorMessage,
+	handleAudioError,
+	isAudioErrorRecoverable,
+	MEDIA_ERROR_MESSAGES,
+	MediaErrorCode,
+	safeAudioOperation,
+} from "@/lib/utils/audio-error";
+
+vi.mock("@/lib/utils/logger", () => ({
+	logError: vi.fn(),
+}));
+
+function makeMediaError(code: number): MediaError {
+	const err = {
+		code,
+		message: `Media error code ${code}`,
+	} as unknown as MediaError;
+	return err;
+}
+
+describe("MediaErrorCode", () => {
+	it("has correct code values", () => {
+		expect(MediaErrorCode.MEDIA_ERR_ABORTED).toBe(1);
+		expect(MediaErrorCode.MEDIA_ERR_NETWORK).toBe(2);
+		expect(MediaErrorCode.MEDIA_ERR_DECODE).toBe(3);
+		expect(MediaErrorCode.MEDIA_ERR_SRC_NOT_SUPPORTED).toBe(4);
+	});
+});
+
+describe("MEDIA_ERROR_MESSAGES", () => {
+	it("has messages for all error codes", () => {
+		expect(MEDIA_ERROR_MESSAGES[MediaErrorCode.MEDIA_ERR_ABORTED]).toBe(
+			"Playback was aborted",
+		);
+		expect(MEDIA_ERROR_MESSAGES[MediaErrorCode.MEDIA_ERR_NETWORK]).toBe(
+			"Network error occurred",
+		);
+		expect(MEDIA_ERROR_MESSAGES[MediaErrorCode.MEDIA_ERR_DECODE]).toBe(
+			"Audio decode error",
+		);
+		expect(
+			MEDIA_ERROR_MESSAGES[MediaErrorCode.MEDIA_ERR_SRC_NOT_SUPPORTED],
+		).toBe("Audio format not supported");
+	});
+});
+
+describe("getAudioErrorMessage", () => {
+	it("returns message for MediaError with known code", () => {
+		const err = makeMediaError(MediaErrorCode.MEDIA_ERR_NETWORK);
+		expect(getAudioErrorMessage(err)).toBe("Network error occurred");
+	});
+
+	it("returns message for MediaError with unknown code", () => {
+		const err = makeMediaError(99);
+		expect(getAudioErrorMessage(err)).toBe("Media error code 99");
+	});
+
+	it("returns message for regular Error", () => {
+		const err = new Error("custom audio error");
+		expect(getAudioErrorMessage(err)).toBe("custom audio error");
+	});
+
+	it("returns default for null", () => {
+		expect(getAudioErrorMessage(null)).toBe("Unknown audio error");
+	});
+
+	it("returns Error message over MediaError message when both present", () => {
+		const err = new Error("error message");
+		expect(getAudioErrorMessage(err)).toBe("error message");
+	});
+});
+
+describe("isAudioErrorRecoverable", () => {
+	it("returns true for null error", () => {
+		expect(isAudioErrorRecoverable(null)).toBe(true);
+	});
+
+	it("returns true for MEDIA_ERR_NETWORK", () => {
+		const err = makeMediaError(MediaErrorCode.MEDIA_ERR_NETWORK);
+		expect(isAudioErrorRecoverable(err)).toBe(true);
+	});
+
+	it("returns false for MEDIA_ERR_ABORTED", () => {
+		const err = makeMediaError(MediaErrorCode.MEDIA_ERR_ABORTED);
+		expect(isAudioErrorRecoverable(err)).toBe(false);
+	});
+
+	it("returns false for MEDIA_ERR_DECODE", () => {
+		const err = makeMediaError(MediaErrorCode.MEDIA_ERR_DECODE);
+		expect(isAudioErrorRecoverable(err)).toBe(false);
+	});
+
+	it("returns false for MEDIA_ERR_SRC_NOT_SUPPORTED", () => {
+		const err = makeMediaError(MediaErrorCode.MEDIA_ERR_SRC_NOT_SUPPORTED);
+		expect(isAudioErrorRecoverable(err)).toBe(false);
+	});
+
+	it("returns true for regular Error", () => {
+		const err = new Error("some error");
+		expect(isAudioErrorRecoverable(err)).toBe(true);
+	});
+});
+
+describe("handleAudioError", () => {
+	it("calls onRetry when error is recoverable", () => {
+		const onRetry = vi.fn();
+		const onFail = vi.fn();
+		const err = makeMediaError(MediaErrorCode.MEDIA_ERR_NETWORK);
+		handleAudioError(err, onRetry, onFail);
+		expect(onRetry).toHaveBeenCalledTimes(1);
+		expect(onFail).not.toHaveBeenCalled();
+	});
+
+	it("calls onFail when error is not recoverable", () => {
+		const onRetry = vi.fn();
+		const onFail = vi.fn();
+		const err = makeMediaError(MediaErrorCode.MEDIA_ERR_DECODE);
+		handleAudioError(err, onRetry, onFail);
+		expect(onRetry).not.toHaveBeenCalled();
+		expect(onFail).toHaveBeenCalledTimes(1);
+	});
+
+	it("calls onRetry when error is null", () => {
+		const onRetry = vi.fn();
+		const onFail = vi.fn();
+		handleAudioError(null, onRetry, onFail);
+		expect(onRetry).toHaveBeenCalledTimes(1);
+		expect(onFail).not.toHaveBeenCalled();
+	});
+});
+
+describe("createErrorHandler", () => {
+	it("returns a function that logs with context", () => {
+		const handler = createErrorHandler("TestContext");
+		expect(typeof handler).toBe("function");
+	});
+});
+
+describe("safeAudioOperation", () => {
+	it("returns result on success", () => {
+		const result = safeAudioOperation(() => 42, "test");
+		expect(result).toBe(42);
+	});
+
+	it("returns undefined on error", () => {
+		const result = safeAudioOperation(() => {
+			throw new Error("fail");
+		}, "test");
+		expect(result).toBeUndefined();
+	});
+
+	it("handles non-Error throws", () => {
+		const result = safeAudioOperation(() => {
+			throw "string error";
+		}, "test");
+		expect(result).toBeUndefined();
+	});
+
+	it("returns object result on success", () => {
+		const obj = { foo: "bar" };
+		const result = safeAudioOperation(() => obj, "test");
+		expect(result).toBe(obj);
+	});
+});

--- a/__tests__/lib/utils/download.test.ts
+++ b/__tests__/lib/utils/download.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+	AUDIO_QUALITY_ORDER,
+	getAvailableQualities,
+	getDownloadUrl,
+	isQualityAvailable,
+	selectBestDownloadUrl,
+} from "@/lib/utils/download";
+import type { DetailedSong, DownloadUrl } from "@/types/entity";
+
+function makeUrl(quality: string, url: string): DownloadUrl {
+	return { quality, url } as DownloadUrl;
+}
+
+describe("AUDIO_QUALITY_ORDER", () => {
+	it("has qualities in descending order", () => {
+		expect(AUDIO_QUALITY_ORDER[0]).toBe("320kbps");
+		expect(AUDIO_QUALITY_ORDER[AUDIO_QUALITY_ORDER.length - 1]).toBe("12kbps");
+	});
+});
+
+describe("selectBestDownloadUrl", () => {
+	it("returns undefined for empty array", () => {
+		expect(selectBestDownloadUrl([])).toBeUndefined();
+	});
+
+	it("returns undefined for undefined input", () => {
+		expect(selectBestDownloadUrl(undefined)).toBeUndefined();
+	});
+
+	it("returns preferred quality when available", () => {
+		const urls = [makeUrl("160kbps", "url160"), makeUrl("320kbps", "url320")];
+		const result = selectBestDownloadUrl(urls, "320kbps");
+		expect(result?.url).toBe("url320");
+	});
+
+	it("falls back to quality order when preferred not available", () => {
+		const urls = [makeUrl("96kbps", "url96"), makeUrl("64kbps", "url64")];
+		const result = selectBestDownloadUrl(urls, "320kbps");
+		expect(result?.quality).toBe("96kbps");
+	});
+
+	it("returns first available when no quality matches", () => {
+		const urls = [makeUrl("unknown", "url_unknown")];
+		const result = selectBestDownloadUrl(urls, "320kbps");
+		expect(result?.quality).toBe("unknown");
+	});
+
+	it("selects highest available from quality order", () => {
+		const urls = [makeUrl("32kbps", "url32"), makeUrl("160kbps", "url160")];
+		const result = selectBestDownloadUrl(urls, "320kbps");
+		expect(result?.quality).toBe("160kbps");
+	});
+
+	it("uses default 320kbps when no preferred specified", () => {
+		const urls = [makeUrl("320kbps", "url320"), makeUrl("160kbps", "url160")];
+		const result = selectBestDownloadUrl(urls);
+		expect(result?.quality).toBe("320kbps");
+	});
+
+	it("handles single item array", () => {
+		const urls = [makeUrl("96kbps", "url96")];
+		const result = selectBestDownloadUrl(urls, "96kbps");
+		expect(result?.url).toBe("url96");
+	});
+});
+
+describe("getDownloadUrl", () => {
+	it("returns URL string from song", () => {
+		const song = {
+			downloadUrl: [makeUrl("320kbps", "https://example.com/song.mp3")],
+		} as DetailedSong;
+		expect(getDownloadUrl(song)).toBe("https://example.com/song.mp3");
+	});
+
+	it("returns undefined when no download URLs", () => {
+		const song = { downloadUrl: [] } as unknown as DetailedSong;
+		expect(getDownloadUrl(song)).toBeUndefined();
+	});
+
+	it("passes preferred quality through", () => {
+		const song = {
+			downloadUrl: [makeUrl("160kbps", "url160"), makeUrl("96kbps", "url96")],
+		} as DetailedSong;
+		expect(getDownloadUrl(song, "96kbps")).toBe("url96");
+	});
+});
+
+describe("getAvailableQualities", () => {
+	it("returns array of quality strings", () => {
+		const urls = [makeUrl("320kbps", "url1"), makeUrl("160kbps", "url2")];
+		expect(getAvailableQualities(urls)).toEqual(["320kbps", "160kbps"]);
+	});
+
+	it("returns empty array for undefined", () => {
+		expect(getAvailableQualities(undefined)).toEqual([]);
+	});
+
+	it("returns empty array for empty array", () => {
+		expect(getAvailableQualities([])).toEqual([]);
+	});
+});
+
+describe("isQualityAvailable", () => {
+	it("returns true when quality exists", () => {
+		const urls = [makeUrl("320kbps", "url1"), makeUrl("160kbps", "url2")];
+		expect(isQualityAvailable(urls, "320kbps")).toBe(true);
+	});
+
+	it("returns false when quality does not exist", () => {
+		const urls = [makeUrl("160kbps", "url2")];
+		expect(isQualityAvailable(urls, "320kbps")).toBe(false);
+	});
+
+	it("returns false for undefined", () => {
+		expect(isQualityAvailable(undefined, "320kbps")).toBe(false);
+	});
+
+	it("returns false for empty array", () => {
+		expect(isQualityAvailable([], "320kbps")).toBe(false);
+	});
+});

--- a/__tests__/lib/utils/error-classifier.test.ts
+++ b/__tests__/lib/utils/error-classifier.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from "vitest";
+import {
+	classifyError,
+	ErrorCategory,
+	getUserErrorMessage,
+	isErrorRetryable,
+	shouldShowError,
+} from "@/lib/utils/error-classifier";
+
+describe("classifyError", () => {
+	describe("TypeError network errors", () => {
+		it("classifies 'Failed to fetch' as NETWORK", () => {
+			const err = new TypeError("Failed to fetch");
+			const result = classifyError(err);
+			expect(result.category).toBe(ErrorCategory.NETWORK);
+			expect(result.isRetryable).toBe(true);
+			expect(result.userMessage).toContain("Network connection failed");
+		});
+
+		it("classifies 'network error' as NETWORK", () => {
+			const err = new TypeError("network error occurred");
+			const result = classifyError(err);
+			expect(result.category).toBe(ErrorCategory.NETWORK);
+		});
+
+		it("classifies 'fetch failed' as NETWORK", () => {
+			const err = new TypeError("fetch failed");
+			const result = classifyError(err);
+			expect(result.category).toBe(ErrorCategory.NETWORK);
+		});
+
+		it("does not classify TypeError without network keywords as NETWORK", () => {
+			const err = new TypeError("some other error");
+			const result = classifyError(err);
+			expect(result.category).not.toBe(ErrorCategory.NETWORK);
+		});
+	});
+
+	describe("Response errors", () => {
+		it("classifies 401 as AUTH", () => {
+			const response = new Response("", {
+				status: 401,
+				statusText: "Unauthorized",
+			});
+			const result = classifyError(response);
+			expect(result.category).toBe(ErrorCategory.AUTH);
+			expect(result.isRetryable).toBe(false);
+			expect(result.userMessage).toContain("log in again");
+		});
+
+		it("classifies 403 as AUTH", () => {
+			const response = new Response("", {
+				status: 403,
+				statusText: "Forbidden",
+			});
+			const result = classifyError(response);
+			expect(result.category).toBe(ErrorCategory.AUTH);
+		});
+
+		it("classifies 400 as VALIDATION", () => {
+			const response = new Response("", {
+				status: 400,
+				statusText: "Bad Request",
+			});
+			const result = classifyError(response);
+			expect(result.category).toBe(ErrorCategory.VALIDATION);
+			expect(result.isRetryable).toBe(false);
+		});
+
+		it("classifies 500 as SERVER", () => {
+			const response = new Response("", {
+				status: 500,
+				statusText: "Internal Server Error",
+			});
+			const result = classifyError(response);
+			expect(result.category).toBe(ErrorCategory.SERVER);
+			expect(result.isRetryable).toBe(true);
+		});
+
+		it("classifies 503 as SERVER", () => {
+			const response = new Response("", {
+				status: 503,
+				statusText: "Service Unavailable",
+			});
+			const result = classifyError(response);
+			expect(result.category).toBe(ErrorCategory.SERVER);
+		});
+
+		it("classifies 404 as CLIENT", () => {
+			const response = new Response("", {
+				status: 404,
+				statusText: "Not Found",
+			});
+			const result = classifyError(response);
+			expect(result.category).toBe(ErrorCategory.CLIENT);
+			expect(result.isRetryable).toBe(false);
+		});
+
+		it("classifies 429 as CLIENT", () => {
+			const response = new Response("", {
+				status: 429,
+				statusText: "Too Many Requests",
+			});
+			const result = classifyError(response);
+			expect(result.category).toBe(ErrorCategory.CLIENT);
+		});
+	});
+
+	describe("Error object keyword matching", () => {
+		it("classifies audio errors", () => {
+			const err = new Error("audio playback failed");
+			const result = classifyError(err);
+			expect(result.category).toBe(ErrorCategory.AUDIO);
+			expect(result.isRetryable).toBe(true);
+			expect(result.userMessage).toContain("Failed to play audio");
+		});
+
+		it("classifies media errors", () => {
+			const err = new Error("media element error");
+			const result = classifyError(err);
+			expect(result.category).toBe(ErrorCategory.AUDIO);
+		});
+
+		it("classifies storage errors", () => {
+			const err = new Error("indexeddb transaction failed");
+			const result = classifyError(err);
+			expect(result.category).toBe(ErrorCategory.STORAGE);
+			expect(result.isRetryable).toBe(false);
+		});
+
+		it("classifies quota exceeded as STORAGE", () => {
+			const err = new Error("quota exceeded limit");
+			const result = classifyError(err);
+			expect(result.category).toBe(ErrorCategory.STORAGE);
+		});
+
+		it("classifies unauthorized errors as AUTH", () => {
+			const err = new Error("unauthorized access");
+			const result = classifyError(err);
+			expect(result.category).toBe(ErrorCategory.AUTH);
+			expect(result.isRetryable).toBe(false);
+		});
+
+		it("classifies unauthenticated errors as AUTH", () => {
+			const err = new Error("unauthenticated request");
+			const result = classifyError(err);
+			expect(result.category).toBe(ErrorCategory.AUTH);
+		});
+
+		it("classifies validation errors", () => {
+			const err = new Error("validation failed for field");
+			const result = classifyError(err);
+			expect(result.category).toBe(ErrorCategory.VALIDATION);
+			expect(result.isRetryable).toBe(false);
+		});
+
+		it("classifies invalid data errors", () => {
+			const err = new Error("invalid input provided");
+			const result = classifyError(err);
+			expect(result.category).toBe(ErrorCategory.VALIDATION);
+		});
+
+		it("classifies unknown errors as UNKNOWN", () => {
+			const err = new Error("something went wrong");
+			const result = classifyError(err);
+			expect(result.category).toBe(ErrorCategory.UNKNOWN);
+			expect(result.isDeveloper).toBe(true);
+			expect(result.isRetryable).toBe(true);
+			expect(result.userMessage).toBeUndefined();
+		});
+	});
+
+	describe("non-Error values", () => {
+		it("classifies null as UNKNOWN", () => {
+			const result = classifyError(null);
+			expect(result.category).toBe(ErrorCategory.UNKNOWN);
+			expect(result.message).toBe("null");
+		});
+
+		it("classifies undefined as UNKNOWN", () => {
+			const result = classifyError(undefined);
+			expect(result.category).toBe(ErrorCategory.UNKNOWN);
+			expect(result.message).toBe("undefined");
+		});
+
+		it("classifies string as UNKNOWN", () => {
+			const result = classifyError("oops");
+			expect(result.category).toBe(ErrorCategory.UNKNOWN);
+			expect(result.message).toBe("oops");
+		});
+
+		it("classifies number as UNKNOWN", () => {
+			const result = classifyError(42);
+			expect(result.category).toBe(ErrorCategory.UNKNOWN);
+			expect(result.message).toBe("42");
+		});
+
+		it("classifies plain object as UNKNOWN", () => {
+			const result = classifyError({ foo: "bar" });
+			expect(result.category).toBe(ErrorCategory.UNKNOWN);
+		});
+	});
+});
+
+describe("getUserErrorMessage", () => {
+	it("returns user message for classified errors", () => {
+		const err = new TypeError("Failed to fetch");
+		expect(getUserErrorMessage(err)).toContain("Network connection failed");
+	});
+
+	it("returns default message for UNKNOWN errors", () => {
+		const err = new Error("something went wrong");
+		expect(getUserErrorMessage(err)).toBe(
+			"An unexpected error occurred. Please try again.",
+		);
+	});
+
+	it("returns default message for null", () => {
+		expect(getUserErrorMessage(null)).toBe(
+			"An unexpected error occurred. Please try again.",
+		);
+	});
+});
+
+describe("shouldShowError", () => {
+	it("returns true for AUTH", () => {
+		expect(shouldShowError(ErrorCategory.AUTH)).toBe(true);
+	});
+
+	it("returns true for AUDIO", () => {
+		expect(shouldShowError(ErrorCategory.AUDIO)).toBe(true);
+	});
+
+	it("returns true for NETWORK", () => {
+		expect(shouldShowError(ErrorCategory.NETWORK)).toBe(true);
+	});
+
+	it("returns true for VALIDATION", () => {
+		expect(shouldShowError(ErrorCategory.VALIDATION)).toBe(true);
+	});
+
+	it("returns false for SERVER", () => {
+		expect(shouldShowError(ErrorCategory.SERVER)).toBe(false);
+	});
+
+	it("returns false for CLIENT", () => {
+		expect(shouldShowError(ErrorCategory.CLIENT)).toBe(false);
+	});
+
+	it("returns false for STORAGE", () => {
+		expect(shouldShowError(ErrorCategory.STORAGE)).toBe(false);
+	});
+
+	it("returns false for UNKNOWN", () => {
+		expect(shouldShowError(ErrorCategory.UNKNOWN)).toBe(false);
+	});
+});
+
+describe("isErrorRetryable", () => {
+	it("returns true for network errors", () => {
+		expect(isErrorRetryable(new TypeError("Failed to fetch"))).toBe(true);
+	});
+
+	it("returns true for server errors", () => {
+		const response = new Response("", { status: 500 });
+		expect(isErrorRetryable(response)).toBe(true);
+	});
+
+	it("returns true for audio errors", () => {
+		expect(isErrorRetryable(new Error("audio playback failed"))).toBe(true);
+	});
+
+	it("returns true for unknown errors", () => {
+		expect(isErrorRetryable(new Error("something went wrong"))).toBe(true);
+	});
+
+	it("returns false for auth errors", () => {
+		const response = new Response("", { status: 401 });
+		expect(isErrorRetryable(response)).toBe(false);
+	});
+
+	it("returns false for validation errors", () => {
+		const response = new Response("", { status: 400 });
+		expect(isErrorRetryable(response)).toBe(false);
+	});
+
+	it("returns false for client errors", () => {
+		const response = new Response("", { status: 404 });
+		expect(isErrorRetryable(response)).toBe(false);
+	});
+
+	it("returns false for storage errors", () => {
+		expect(isErrorRetryable(new Error("indexeddb failed"))).toBe(false);
+	});
+
+	it("returns false for null", () => {
+		expect(isErrorRetryable(null)).toBe(false);
+	});
+});

--- a/__tests__/lib/utils/image.test.ts
+++ b/__tests__/lib/utils/image.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+	getImageQuality,
+	getLargestImage,
+	getSmallestImage,
+	sortImagesByQuality,
+} from "@/lib/utils/image";
+import type { Image as ImageType } from "@/types/entity";
+
+function makeImage(quality: string, url: string): ImageType {
+	return { quality, url } as ImageType;
+}
+
+describe("getImageQuality", () => {
+	it("parses standard quality string", () => {
+		expect(getImageQuality(makeImage("500x500", "url"))).toBe(500);
+	});
+
+	it("parses different dimensions", () => {
+		expect(getImageQuality(makeImage("1000x1000", "url"))).toBe(1000);
+		expect(getImageQuality(makeImage("50x50", "url"))).toBe(50);
+	});
+
+	it("returns 0 for undefined quality", () => {
+		expect(
+			getImageQuality(makeImage(undefined as unknown as string, "url")),
+		).toBe(0);
+	});
+
+	it("returns 0 for empty string", () => {
+		expect(getImageQuality(makeImage("", "url"))).toBe(0);
+	});
+
+	it("returns 0 for non-numeric quality", () => {
+		expect(getImageQuality(makeImage("high", "url"))).toBe(0);
+	});
+});
+
+describe("sortImagesByQuality", () => {
+	it("sorts images ascending by quality", () => {
+		const images = [
+			makeImage("500x500", "url500"),
+			makeImage("150x150", "url150"),
+			makeImage("1000x1000", "url1000"),
+		];
+		const sorted = sortImagesByQuality(images);
+		expect(sorted[0]?.url).toBe("url150");
+		expect(sorted[1]?.url).toBe("url500");
+		expect(sorted[2]?.url).toBe("url1000");
+	});
+
+	it("does not mutate original array", () => {
+		const images = [
+			makeImage("500x500", "url500"),
+			makeImage("150x150", "url150"),
+		];
+		const sorted = sortImagesByQuality(images);
+		expect(images[0]?.url).toBe("url500");
+		expect(sorted[0]?.url).not.toBe("url500");
+	});
+
+	it("handles empty array", () => {
+		expect(sortImagesByQuality([])).toEqual([]);
+	});
+
+	it("handles single image", () => {
+		const images = [makeImage("500x500", "url500")];
+		expect(sortImagesByQuality(images)).toEqual(images);
+	});
+});
+
+describe("getSmallestImage", () => {
+	it("returns smallest image URL", () => {
+		const images = [
+			makeImage("500x500", "url500"),
+			makeImage("150x150", "url150"),
+			makeImage("1000x1000", "url1000"),
+		];
+		expect(getSmallestImage(images)).toBe("url150");
+	});
+
+	it("returns placeholder for empty array", () => {
+		expect(getSmallestImage([])).toBe(
+			"https://placehold.co/500x500.webp?text=Image+Not+Found",
+		);
+	});
+
+	it("returns placeholder for image without URL", () => {
+		const images = [makeImage("500x500", "")];
+		expect(getSmallestImage(images)).toBe(
+			"https://placehold.co/500x500.webp?text=Image+Not+Found",
+		);
+	});
+
+	it("handles single image", () => {
+		const images = [makeImage("500x500", "url500")];
+		expect(getSmallestImage(images)).toBe("url500");
+	});
+});
+
+describe("getLargestImage", () => {
+	it("returns largest image URL", () => {
+		const images = [
+			makeImage("500x500", "url500"),
+			makeImage("150x150", "url150"),
+			makeImage("1000x1000", "url1000"),
+		];
+		expect(getLargestImage(images)).toBe("url1000");
+	});
+
+	it("returns placeholder for empty array", () => {
+		expect(getLargestImage([])).toBe(
+			"https://placehold.co/500x500.webp?text=Image+Not+Found",
+		);
+	});
+
+	it("returns placeholder for image without URL", () => {
+		const images = [makeImage("500x500", "")];
+		expect(getLargestImage(images)).toBe(
+			"https://placehold.co/500x500.webp?text=Image+Not+Found",
+		);
+	});
+
+	it("handles single image", () => {
+		const images = [makeImage("500x500", "url500")];
+		expect(getLargestImage(images)).toBe("url500");
+	});
+});

--- a/__tests__/lib/utils/logger.test.ts
+++ b/__tests__/lib/utils/logger.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { debug, logError, logInfo, logWarning } from "@/lib/utils/logger";
+
+describe("logger", () => {
+	let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		consoleSpy.mockRestore();
+	});
+
+	describe("in development mode", () => {
+		it("logError calls console.error", () => {
+			logError("TestContext", new Error("test error"));
+			expect(consoleSpy).toHaveBeenCalled();
+		});
+
+		it("logError formats with context", () => {
+			logError("TestContext", new Error("test error"));
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.stringContaining("[TestContext]"),
+				expect.any(Error),
+			);
+		});
+	});
+
+	describe("logWarning", () => {
+		let warnSpy: ReturnType<typeof vi.spyOn>;
+
+		beforeEach(() => {
+			warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		});
+
+		afterEach(() => {
+			warnSpy.mockRestore();
+		});
+
+		it("calls console.warn in development", () => {
+			logWarning("TestContext", "test message");
+			expect(warnSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe("logInfo", () => {
+		let logSpy: ReturnType<typeof vi.spyOn>;
+
+		beforeEach(() => {
+			logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		});
+
+		afterEach(() => {
+			logSpy.mockRestore();
+		});
+
+		it("calls console.log in development", () => {
+			logInfo("TestContext", "test message");
+			expect(logSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe("debug", () => {
+		let debugSpy: ReturnType<typeof vi.spyOn>;
+
+		beforeEach(() => {
+			debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+		});
+
+		afterEach(() => {
+			debugSpy.mockRestore();
+		});
+
+		it("calls console.debug in development", () => {
+			debug("TestContext", "arg1", "arg2");
+			expect(debugSpy).toHaveBeenCalled();
+		});
+
+		it("passes multiple arguments", () => {
+			debug("TestContext", "arg1", { key: "value" });
+			expect(debugSpy).toHaveBeenCalledWith(
+				expect.stringContaining("[TestContext]"),
+				"arg1",
+				{ key: "value" },
+			);
+		});
+	});
+});

--- a/__tests__/lib/utils/normalize-error.test.ts
+++ b/__tests__/lib/utils/normalize-error.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import {
+	getErrorCode,
+	getErrorMessage,
+	isApiError,
+	isNetworkError,
+	normalizeError,
+	safeJsonParse,
+	safeJsonStringify,
+} from "@/lib/utils/normalize-error";
+
+describe("normalizeError", () => {
+	it("returns Error instance unchanged", () => {
+		const err = new Error("test");
+		expect(normalizeError(err)).toBe(err);
+	});
+
+	it("converts string to Error", () => {
+		const result = normalizeError("something broke");
+		expect(result).toBeInstanceOf(Error);
+		expect(result.message).toBe("something broke");
+	});
+
+	it("converts null to Error with default message", () => {
+		const result = normalizeError(null);
+		expect(result.message).toBe("Unknown error occurred");
+	});
+
+	it("converts undefined to Error with default message", () => {
+		const result = normalizeError(undefined);
+		expect(result.message).toBe("Unknown error occurred");
+	});
+
+	it("extracts message from object with message property", () => {
+		const result = normalizeError({ message: "custom error" });
+		expect(result.message).toBe("custom error");
+	});
+
+	it("stringifies object without message property", () => {
+		const result = normalizeError({ foo: "bar" });
+		expect(result.message).toBe('{"foo":"bar"}');
+	});
+
+	it("converts number to Error", () => {
+		const result = normalizeError(42);
+		expect(result.message).toBe("42");
+	});
+
+	it("converts boolean to Error", () => {
+		const result = normalizeError(false);
+		expect(result.message).toBe("false");
+	});
+});
+
+describe("getErrorMessage", () => {
+	it("extracts message from Error", () => {
+		expect(getErrorMessage(new Error("test"))).toBe("test");
+	});
+
+	it("returns string as-is", () => {
+		expect(getErrorMessage("error text")).toBe("error text");
+	});
+
+	it("returns default for null", () => {
+		expect(getErrorMessage(null)).toBe("Unknown error");
+	});
+
+	it("returns default for undefined", () => {
+		expect(getErrorMessage(undefined)).toBe("Unknown error");
+	});
+
+	it("extracts message from object with message property", () => {
+		expect(getErrorMessage({ message: "obj error" })).toBe("obj error");
+	});
+
+	it("stringifies object without message property", () => {
+		expect(getErrorMessage({ code: 500 })).toBe('{"code":500}');
+	});
+
+	it("converts number to string", () => {
+		expect(getErrorMessage(404)).toBe("404");
+	});
+});
+
+describe("getErrorCode", () => {
+	it("extracts code from Error with code property", () => {
+		const err = new Error("test") as Error & { code: string };
+		err.code = "ENOENT";
+		expect(getErrorCode(err)).toBe("ENOENT");
+	});
+
+	it("extracts code from plain object", () => {
+		expect(getErrorCode({ code: "ERR_TIMEOUT" })).toBe("ERR_TIMEOUT");
+	});
+
+	it("converts numeric code to string", () => {
+		expect(getErrorCode({ code: 500 })).toBe("500");
+	});
+
+	it("returns undefined for Error without code", () => {
+		expect(getErrorCode(new Error("test"))).toBeUndefined();
+	});
+
+	it("returns undefined for object without code", () => {
+		expect(getErrorCode({ message: "no code" })).toBeUndefined();
+	});
+
+	it("returns undefined for string", () => {
+		expect(getErrorCode("error")).toBeUndefined();
+	});
+
+	it("returns undefined for null", () => {
+		expect(getErrorCode(null)).toBeUndefined();
+	});
+});
+
+describe("isApiError", () => {
+	it("returns true for object with status", () => {
+		expect(isApiError({ status: 404 })).toBe(true);
+	});
+
+	it("returns true for object with statusCode", () => {
+		expect(isApiError({ statusCode: 500 })).toBe(true);
+	});
+
+	it("returns true for object with code", () => {
+		expect(isApiError({ code: "ERR" })).toBe(true);
+	});
+
+	it("returns false for object without API properties", () => {
+		expect(isApiError({ message: "error" })).toBe(false);
+	});
+
+	it("returns false for string", () => {
+		expect(isApiError("error")).toBe(false);
+	});
+
+	it("returns false for null", () => {
+		expect(isApiError(null)).toBe(false);
+	});
+
+	it("returns false for undefined", () => {
+		expect(isApiError(undefined)).toBe(false);
+	});
+});
+
+describe("isNetworkError", () => {
+	it("detects 'network' keyword", () => {
+		expect(isNetworkError(new Error("Network failure"))).toBe(true);
+	});
+
+	it("detects 'fetch' keyword", () => {
+		expect(isNetworkError(new Error("Fetch failed"))).toBe(true);
+	});
+
+	it("detects 'timeout' keyword", () => {
+		expect(isNetworkError(new Error("Request timeout"))).toBe(true);
+	});
+
+	it("detects 'connection' keyword", () => {
+		expect(isNetworkError(new Error("Connection refused"))).toBe(true);
+	});
+
+	it("is case-insensitive", () => {
+		expect(isNetworkError(new Error("NETWORK ERROR"))).toBe(true);
+		expect(isNetworkError(new Error("Fetch Error"))).toBe(true);
+	});
+
+	it("returns false for non-network errors", () => {
+		expect(isNetworkError(new Error("File not found"))).toBe(false);
+		expect(isNetworkError(new Error("Validation failed"))).toBe(false);
+	});
+
+	it("returns false for null", () => {
+		expect(isNetworkError(null)).toBe(false);
+	});
+
+	it("returns false for string without network keywords", () => {
+		expect(isNetworkError("some error")).toBe(false);
+	});
+});
+
+describe("safeJsonParse", () => {
+	it("parses valid JSON", () => {
+		expect(safeJsonParse('{"a":1}', {})).toEqual({ a: 1 });
+	});
+
+	it("parses JSON array", () => {
+		expect(safeJsonParse("[1,2,3]", [])).toEqual([1, 2, 3]);
+	});
+
+	it("parses JSON string", () => {
+		expect(safeJsonParse('"hello"', "")).toBe("hello");
+	});
+
+	it("parses JSON number", () => {
+		expect(safeJsonParse("42", 0)).toBe(42);
+	});
+
+	it("returns fallback for invalid JSON", () => {
+		expect(safeJsonParse("{invalid}", { fallback: true })).toEqual({
+			fallback: true,
+		});
+	});
+
+	it("returns fallback for empty string", () => {
+		expect(safeJsonParse("", "default")).toBe("default");
+	});
+});
+
+describe("safeJsonStringify", () => {
+	it("stringifies valid object", () => {
+		expect(safeJsonStringify({ a: 1 })).toBe('{"a":1}');
+	});
+
+	it("stringifies array", () => {
+		expect(safeJsonStringify([1, 2, 3])).toBe("[1,2,3]");
+	});
+
+	it("stringifies null", () => {
+		expect(safeJsonStringify(null)).toBe("null");
+	});
+
+	it("returns fallback for circular reference", () => {
+		const obj: Record<string, unknown> = {};
+		obj.self = obj;
+		expect(safeJsonStringify(obj, "circular")).toBe("circular");
+	});
+
+	it("returns empty string fallback by default", () => {
+		const obj: Record<string, unknown> = {};
+		obj.self = obj;
+		expect(safeJsonStringify(obj)).toBe("");
+	});
+
+	it("returns custom fallback", () => {
+		const obj: Record<string, unknown> = {};
+		obj.self = obj;
+		expect(safeJsonStringify(obj, "error")).toBe("error");
+	});
+});

--- a/__tests__/lib/utils/storage.test.ts
+++ b/__tests__/lib/utils/storage.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	clearStorage,
+	getStorageInfo,
+	getStorageItem,
+	hasStorageSpace,
+	isStorageAvailable,
+	removeStorageItem,
+	setStorageItem,
+} from "@/lib/utils/storage";
+
+const localStorageMock = (() => {
+	let store: Record<string, string> = {};
+	return {
+		getItem: vi.fn((key: string) => store[key] ?? null),
+		setItem: vi.fn((key: string, value: string) => {
+			store[key] = value;
+		}),
+		removeItem: vi.fn((key: string) => {
+			delete store[key];
+		}),
+		key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+		get length() {
+			return Object.keys(store).length;
+		},
+		clear: vi.fn(() => {
+			store = {};
+		}),
+	};
+})();
+
+vi.stubGlobal("localStorage", localStorageMock);
+
+vi.mock("@/lib/utils/logger", () => ({
+	logError: vi.fn(),
+}));
+
+describe("storage", () => {
+	beforeEach(() => {
+		localStorageMock.clear();
+		vi.clearAllMocks();
+	});
+
+	describe("getStorageItem", () => {
+		it("returns stored value", () => {
+			localStorageMock.setItem("songs:test", JSON.stringify({ foo: "bar" }));
+			const result = getStorageItem("test", {});
+			expect(result).toEqual({ foo: "bar" });
+		});
+
+		it("returns fallback when key not found", () => {
+			const fallback = { default: true };
+			const result = getStorageItem("nonexistent", fallback);
+			expect(result).toEqual(fallback);
+		});
+
+		it("returns fallback on error", () => {
+			localStorageMock.getItem.mockImplementationOnce(() => {
+				throw new Error("Storage error");
+			});
+			const result = getStorageItem("test", "fallback");
+			expect(result).toBe("fallback");
+		});
+	});
+
+	describe("setStorageItem", () => {
+		it("stores value as JSON", () => {
+			const result = setStorageItem("test", { foo: "bar" });
+			expect(result).toBe(true);
+			expect(localStorageMock.setItem).toHaveBeenCalledWith(
+				"songs:test",
+				'{"foo":"bar"}',
+			);
+		});
+
+		it("returns false on error", () => {
+			localStorageMock.setItem.mockImplementationOnce(() => {
+				throw new Error("Storage error");
+			});
+			const result = setStorageItem("test", "value");
+			expect(result).toBe(false);
+		});
+	});
+
+	describe("removeStorageItem", () => {
+		it("removes item", () => {
+			localStorageMock.setItem("songs:test", "value");
+			const result = removeStorageItem("test");
+			expect(result).toBe(true);
+			expect(localStorageMock.removeItem).toHaveBeenCalledWith("songs:test");
+		});
+
+		it("returns false on error", () => {
+			localStorageMock.removeItem.mockImplementationOnce(() => {
+				throw new Error("Storage error");
+			});
+			const result = removeStorageItem("test");
+			expect(result).toBe(false);
+		});
+	});
+
+	describe("clearStorage", () => {
+		it("clears only namespaced items", () => {
+			localStorageMock.setItem("songs:key1", "value1");
+			localStorageMock.setItem("songs:key2", "value2");
+			localStorageMock.setItem("other:key", "value");
+			const count = clearStorage();
+			expect(count).toBe(2);
+		});
+
+		it("returns 0 when no items", () => {
+			const count = clearStorage();
+			expect(count).toBe(0);
+		});
+
+		it("handles errors gracefully", () => {
+			localStorageMock.key.mockImplementationOnce(() => {
+				throw new Error("Error");
+			});
+			const count = clearStorage();
+			expect(count).toBe(0);
+		});
+	});
+
+	describe("isStorageAvailable", () => {
+		it("returns true when storage works", () => {
+			expect(isStorageAvailable()).toBe(true);
+		});
+
+		it("returns false when storage throws", () => {
+			localStorageMock.setItem.mockImplementationOnce(() => {
+				throw new Error("Quota exceeded");
+			});
+			expect(isStorageAvailable()).toBe(false);
+		});
+	});
+
+	describe("getStorageInfo", () => {
+		it("returns storage info when available", async () => {
+			vi.stubGlobal("navigator", {
+				storage: {
+					estimate: vi.fn().mockResolvedValue({ usage: 1000, quota: 1000000 }),
+				},
+			});
+			const result = await getStorageInfo();
+			expect(result).toEqual({ usage: 1000, quota: 1000000 });
+			vi.unstubAllGlobals();
+		});
+
+		it("returns undefined when not available", async () => {
+			vi.stubGlobal("navigator", {});
+			const result = await getStorageInfo();
+			expect(result).toBeUndefined();
+			vi.unstubAllGlobals();
+		});
+	});
+
+	describe("hasStorageSpace", () => {
+		it("returns true when space available", async () => {
+			vi.stubGlobal("navigator", {
+				storage: {
+					estimate: vi.fn().mockResolvedValue({ usage: 1000, quota: 1000000 }),
+				},
+			});
+			const result = await hasStorageSpace(1000);
+			expect(result).toBe(true);
+			vi.unstubAllGlobals();
+		});
+
+		it("returns false when over quota", async () => {
+			vi.stubGlobal("navigator", {
+				storage: {
+					estimate: vi
+						.fn()
+						.mockResolvedValue({ usage: 999999, quota: 1000000 }),
+				},
+			});
+			const result = await hasStorageSpace(10000);
+			expect(result).toBe(false);
+			vi.unstubAllGlobals();
+		});
+
+		it("returns true when estimate fails", async () => {
+			vi.stubGlobal("navigator", {
+				storage: {
+					estimate: vi.fn().mockRejectedValue(new Error("Error")),
+				},
+			});
+			const result = await hasStorageSpace();
+			expect(result).toBe(true);
+			vi.unstubAllGlobals();
+		});
+	});
+});

--- a/__tests__/lib/utils/time.test.ts
+++ b/__tests__/lib/utils/time.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import {
+	calculateProgress,
+	clampTime,
+	formatDuration,
+	formatTime,
+	percentToVolume,
+	progressToTime,
+	volumeToPercent,
+} from "@/lib/utils/time";
+
+describe("formatTime", () => {
+	it("formats zero seconds correctly", () => {
+		expect(formatTime(0)).toBe("0:00");
+	});
+
+	it("formats whole seconds correctly", () => {
+		expect(formatTime(65)).toBe("1:05");
+		expect(formatTime(120)).toBe("2:00");
+		expect(formatTime(3661)).toBe("61:01");
+	});
+
+	it("truncates fractional seconds", () => {
+		expect(formatTime(59.9)).toBe("0:59");
+		expect(formatTime(60.999)).toBe("1:00");
+	});
+
+	it("formats negative seconds", () => {
+		expect(formatTime(-5)).toBe("-1:-5");
+	});
+
+	it("handles NaN", () => {
+		expect(formatTime(NaN)).toBe("0:00");
+	});
+
+	it("handles Infinity", () => {
+		expect(formatTime(Infinity)).toBe("0:00");
+		expect(formatTime(-Infinity)).toBe("0:00");
+	});
+});
+
+describe("formatDuration", () => {
+	it("returns 0:00 for zero", () => {
+		expect(formatDuration(0)).toBe("0:00");
+	});
+
+	it("returns 0:00 for NaN", () => {
+		expect(formatDuration(NaN)).toBe("0:00");
+	});
+
+	it("returns 0:00 for Infinity", () => {
+		expect(formatDuration(Infinity)).toBe("0:00");
+		expect(formatDuration(-Infinity)).toBe("0:00");
+	});
+
+	it("formats valid durations", () => {
+		expect(formatDuration(180)).toBe("3:00");
+		expect(formatDuration(245.5)).toBe("4:05");
+	});
+});
+
+describe("percentToVolume", () => {
+	it("converts 0% to 0", () => {
+		expect(percentToVolume(0)).toBe(0);
+	});
+
+	it("converts 100% to 1", () => {
+		expect(percentToVolume(100)).toBe(1);
+	});
+
+	it("converts 50% to 0.5", () => {
+		expect(percentToVolume(50)).toBe(0.5);
+	});
+
+	it("clamps negative percentages to 0", () => {
+		expect(percentToVolume(-10)).toBe(0);
+		expect(percentToVolume(-100)).toBe(0);
+	});
+
+	it("clamps percentages over 100 to 1", () => {
+		expect(percentToVolume(150)).toBe(1);
+		expect(percentToVolume(200)).toBe(1);
+	});
+});
+
+describe("volumeToPercent", () => {
+	it("converts 0 to 0%", () => {
+		expect(volumeToPercent(0)).toBe(0);
+	});
+
+	it("converts 1 to 100%", () => {
+		expect(volumeToPercent(1)).toBe(100);
+	});
+
+	it("converts 0.5 to 50%", () => {
+		expect(volumeToPercent(0.5)).toBe(50);
+	});
+
+	it("rounds to nearest integer", () => {
+		expect(volumeToPercent(0.333)).toBe(33);
+		expect(volumeToPercent(0.667)).toBe(67);
+	});
+
+	it("handles values outside 0-1 range", () => {
+		expect(volumeToPercent(1.5)).toBe(150);
+		expect(volumeToPercent(-0.5)).toBe(-50);
+	});
+});
+
+describe("percentToVolume and volumeToPercent round-trip", () => {
+	it("round-trips common values", () => {
+		expect(volumeToPercent(percentToVolume(0))).toBe(0);
+		expect(volumeToPercent(percentToVolume(25))).toBe(25);
+		expect(volumeToPercent(percentToVolume(50))).toBe(50);
+		expect(volumeToPercent(percentToVolume(75))).toBe(75);
+		expect(volumeToPercent(percentToVolume(100))).toBe(100);
+	});
+});
+
+describe("clampTime", () => {
+	it("clamps negative time to 0", () => {
+		expect(clampTime(-5, 100)).toBe(0);
+	});
+
+	it("clamps time over duration to duration", () => {
+		expect(clampTime(150, 100)).toBe(100);
+	});
+
+	it("returns time when within range", () => {
+		expect(clampTime(50, 100)).toBe(50);
+	});
+
+	it("returns time when duration is zero", () => {
+		expect(clampTime(50, 0)).toBe(50);
+	});
+
+	it("returns time when duration is NaN", () => {
+		expect(clampTime(50, NaN)).toBe(50);
+	});
+
+	it("returns time when duration is Infinity", () => {
+		expect(clampTime(50, Infinity)).toBe(50);
+	});
+});
+
+describe("calculateProgress", () => {
+	it("calculates 0% progress", () => {
+		expect(calculateProgress(0, 100)).toBe(0);
+	});
+
+	it("calculates 50% progress", () => {
+		expect(calculateProgress(50, 100)).toBe(50);
+	});
+
+	it("calculates 100% progress", () => {
+		expect(calculateProgress(100, 100)).toBe(100);
+	});
+
+	it("clamps progress below 0 to 0", () => {
+		expect(calculateProgress(-10, 100)).toBe(0);
+	});
+
+	it("clamps progress above 100 to 100", () => {
+		expect(calculateProgress(150, 100)).toBe(100);
+	});
+
+	it("returns 0 when duration is zero", () => {
+		expect(calculateProgress(50, 0)).toBe(0);
+	});
+
+	it("returns 0 when duration is NaN", () => {
+		expect(calculateProgress(50, NaN)).toBe(0);
+	});
+
+	it("returns 0 when duration is Infinity", () => {
+		expect(calculateProgress(50, Infinity)).toBe(0);
+	});
+});
+
+describe("progressToTime", () => {
+	it("converts 0% progress to 0 seconds", () => {
+		expect(progressToTime(0, 100)).toBe(0);
+	});
+
+	it("converts 50% progress to half duration", () => {
+		expect(progressToTime(50, 100)).toBe(50);
+	});
+
+	it("converts 100% progress to full duration", () => {
+		expect(progressToTime(100, 100)).toBe(100);
+	});
+
+	it("clamps progress below 0 to 0", () => {
+		expect(progressToTime(-10, 100)).toBe(0);
+	});
+
+	it("clamps progress above 100 to duration", () => {
+		expect(progressToTime(150, 100)).toBe(100);
+	});
+
+	it("returns 0 when duration is zero", () => {
+		expect(progressToTime(50, 0)).toBe(0);
+	});
+
+	it("returns 0 when duration is NaN", () => {
+		expect(progressToTime(50, NaN)).toBe(0);
+	});
+
+	it("returns 0 when duration is Infinity", () => {
+		expect(progressToTime(50, Infinity)).toBe(0);
+	});
+});
+
+describe("calculateProgress and progressToTime round-trip", () => {
+	it("round-trips common values", () => {
+		const duration = 200;
+		const times = [0, 50, 100, 150, 200];
+		for (const time of times) {
+			const progress = calculateProgress(time, duration);
+			const roundTripped = progressToTime(progress, duration);
+			expect(roundTripped).toBe(time);
+		}
+	});
+});

--- a/__tests__/lib/validations/backup.test.ts
+++ b/__tests__/lib/validations/backup.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from "vitest";
+import {
+	BackupDataSchema,
+	FavoriteItemSchema,
+	HistoryItemSchema,
+	isValidPlaylistName,
+	isValidSearchQuery,
+	PlaylistItemSchema,
+	sanitizeSearchQuery,
+	VALIDATION,
+} from "@/lib/validations/backup";
+
+describe("BackupDataSchema", () => {
+	it("validates complete backup data", () => {
+		const data = {
+			version: "1.0.0",
+			timestamp: Date.now(),
+		};
+		expect(BackupDataSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("validates with optional localStorage", () => {
+		const data = {
+			version: "1.0.0",
+			timestamp: Date.now(),
+			localStorage: { key: "value" },
+		};
+		expect(BackupDataSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("validates with optional indexedDB", () => {
+		const data = {
+			version: "1.0.0",
+			timestamp: Date.now(),
+			indexedDB: {
+				store: {
+					song1: [
+						{
+							id: "song1",
+							name: "Test Song",
+							type: "song",
+							year: "2024",
+							releaseDate: "2024-01-01",
+							duration: 180,
+							label: "Test",
+							explicitContent: false,
+							playCount: 100,
+							language: "hindi",
+							hasLyrics: false,
+							lyricsId: null,
+							url: "https://example.com/song",
+							copyright: "2024",
+							album: {
+								id: "album1",
+								name: "Album",
+								url: "https://example.com/album",
+							},
+							artists: { primary: [], featured: [], all: [] },
+							image: [],
+							downloadUrl: [],
+						},
+					],
+				},
+			},
+		};
+		expect(BackupDataSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("fails without version", () => {
+		const data = { timestamp: Date.now() };
+		expect(BackupDataSchema.safeParse(data).success).toBe(false);
+	});
+
+	it("fails without timestamp", () => {
+		const data = { version: "1.0.0" };
+		expect(BackupDataSchema.safeParse(data).success).toBe(false);
+	});
+
+	it("fails with wrong types", () => {
+		const data = { version: 123, timestamp: "not-a-number" };
+		expect(BackupDataSchema.safeParse(data).success).toBe(false);
+	});
+});
+
+describe("FavoriteItemSchema", () => {
+	it("validates song favorite", () => {
+		expect(
+			FavoriteItemSchema.safeParse({ id: "1", type: "song" }).success,
+		).toBe(true);
+	});
+
+	it("validates album favorite", () => {
+		expect(
+			FavoriteItemSchema.safeParse({ id: "2", type: "album" }).success,
+		).toBe(true);
+	});
+
+	it("validates artist favorite", () => {
+		expect(
+			FavoriteItemSchema.safeParse({ id: "3", type: "artist" }).success,
+		).toBe(true);
+	});
+
+	it("fails with invalid type", () => {
+		expect(
+			FavoriteItemSchema.safeParse({ id: "1", type: "playlist" }).success,
+		).toBe(false);
+	});
+
+	it("fails without id", () => {
+		expect(FavoriteItemSchema.safeParse({ type: "song" }).success).toBe(false);
+	});
+
+	it("fails without type", () => {
+		expect(FavoriteItemSchema.safeParse({ id: "1" }).success).toBe(false);
+	});
+});
+
+describe("PlaylistItemSchema", () => {
+	it("validates minimal playlist", () => {
+		const data = { id: "1", name: "My Playlist", songIds: [] };
+		expect(PlaylistItemSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("validates full playlist", () => {
+		const data = {
+			id: "1",
+			name: "My Playlist",
+			songIds: ["a", "b"],
+			createdAt: "2024-01-01T00:00:00.000Z",
+			updatedAt: "2024-01-02T00:00:00.000Z",
+		};
+		expect(PlaylistItemSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("fails with empty name", () => {
+		const data = { id: "1", name: "", songIds: [] };
+		expect(PlaylistItemSchema.safeParse(data).success).toBe(false);
+	});
+
+	it("fails with name over 100 chars", () => {
+		const data = { id: "1", name: "a".repeat(101), songIds: [] };
+		expect(PlaylistItemSchema.safeParse(data).success).toBe(false);
+	});
+
+	it("fails without songIds", () => {
+		const data = { id: "1", name: "Playlist" };
+		expect(PlaylistItemSchema.safeParse(data).success).toBe(false);
+	});
+});
+
+describe("HistoryItemSchema", () => {
+	it("validates minimal history item", () => {
+		const data = { songId: "1", playedAt: "2024-01-01T00:00:00.000Z" };
+		expect(HistoryItemSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("validates with optional duration", () => {
+		const data = {
+			songId: "1",
+			playedAt: "2024-01-01T00:00:00.000Z",
+			duration: 180,
+		};
+		expect(HistoryItemSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("fails with invalid datetime", () => {
+		const data = { songId: "1", playedAt: "not-a-date" };
+		expect(HistoryItemSchema.safeParse(data).success).toBe(false);
+	});
+
+	it("fails without songId", () => {
+		const data = { playedAt: "2024-01-01T00:00:00.000Z" };
+		expect(HistoryItemSchema.safeParse(data).success).toBe(false);
+	});
+});
+
+describe("VALIDATION constants", () => {
+	it("has correct search query limits", () => {
+		expect(VALIDATION.SEARCH_QUERY.min).toBe(1);
+		expect(VALIDATION.SEARCH_QUERY.max).toBe(500);
+	});
+
+	it("has correct playlist name limits", () => {
+		expect(VALIDATION.PLAYLIST_NAME.min).toBe(1);
+		expect(VALIDATION.PLAYLIST_NAME.max).toBe(100);
+	});
+
+	it("has correct import size limit", () => {
+		expect(VALIDATION.IMPORT_SIZE.max).toBe(10 * 1024 * 1024);
+	});
+
+	it("has correct song title limits", () => {
+		expect(VALIDATION.SONG_TITLE.min).toBe(1);
+		expect(VALIDATION.SONG_TITLE.max).toBe(500);
+	});
+
+	it("has correct artist name limits", () => {
+		expect(VALIDATION.ARTIST_NAME.min).toBe(1);
+		expect(VALIDATION.ARTIST_NAME.max).toBe(200);
+	});
+
+	it("has correct album name limits", () => {
+		expect(VALIDATION.ALBUM_NAME.min).toBe(1);
+		expect(VALIDATION.ALBUM_NAME.max).toBe(300);
+	});
+});
+
+describe("isValidSearchQuery", () => {
+	it("returns true for valid query", () => {
+		expect(isValidSearchQuery("hello")).toBe(true);
+	});
+
+	it("returns true for single character", () => {
+		expect(isValidSearchQuery("a")).toBe(true);
+	});
+
+	it("returns true for max length", () => {
+		expect(isValidSearchQuery("a".repeat(500))).toBe(true);
+	});
+
+	it("returns false for empty string", () => {
+		expect(isValidSearchQuery("")).toBe(false);
+	});
+
+	it("returns false for over max length", () => {
+		expect(isValidSearchQuery("a".repeat(501))).toBe(false);
+	});
+});
+
+describe("isValidPlaylistName", () => {
+	it("returns true for valid name", () => {
+		expect(isValidPlaylistName("My Playlist")).toBe(true);
+	});
+
+	it("returns true for single character", () => {
+		expect(isValidPlaylistName("a")).toBe(true);
+	});
+
+	it("returns true for max length", () => {
+		expect(isValidPlaylistName("a".repeat(100))).toBe(true);
+	});
+
+	it("returns false for empty string", () => {
+		expect(isValidPlaylistName("")).toBe(false);
+	});
+
+	it("returns false for over max length", () => {
+		expect(isValidPlaylistName("a".repeat(101))).toBe(false);
+	});
+});
+
+describe("sanitizeSearchQuery", () => {
+	it("trims whitespace", () => {
+		expect(sanitizeSearchQuery("  hello  ")).toBe("hello");
+	});
+
+	it("removes control characters", () => {
+		const input = `hello\x00world`;
+		expect(sanitizeSearchQuery(input)).toBe("helloworld");
+	});
+
+	it("removes tab character", () => {
+		const input = "hello\tworld";
+		expect(sanitizeSearchQuery(input)).toBe("helloworld");
+	});
+
+	it("removes newline character", () => {
+		const input = "hello\nworld";
+		expect(sanitizeSearchQuery(input)).toBe("helloworld");
+	});
+
+	it("removes DEL character (127)", () => {
+		const input = `hello\x7Fworld`;
+		expect(sanitizeSearchQuery(input)).toBe("helloworld");
+	});
+
+	it("preserves printable characters", () => {
+		expect(sanitizeSearchQuery("hello world!@#$%^&*()")).toBe(
+			"hello world!@#$%^&*()",
+		);
+	});
+
+	it("truncates to max length", () => {
+		const input = "a".repeat(600);
+		const result = sanitizeSearchQuery(input);
+		expect(result.length).toBe(500);
+	});
+
+	it("handles multiple control characters", () => {
+		const input = `\x00a\x01b\x02c`;
+		expect(sanitizeSearchQuery(input)).toBe("abc");
+	});
+
+	it("returns empty string for only control characters", () => {
+		expect(sanitizeSearchQuery("\x00\x01\x02")).toBe("");
+	});
+
+	it("handles empty input", () => {
+		expect(sanitizeSearchQuery("")).toBe("");
+	});
+});

--- a/__tests__/lib/validations/entities.test.ts
+++ b/__tests__/lib/validations/entities.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+	AlbumMiniSchema,
+	ArtistMiniSchema,
+	createPaginatedResponseSchema,
+	DetailedAlbumSchema,
+	DetailedArtistSchema,
+	DetailedPlaylistSchema,
+	DetailedSongSchema,
+	DownloadUrlSchema,
+	ImageSchema,
+	LocalPlaylistSchema,
+	parseEntity,
+	SearchResponseSchema,
+} from "@/lib/validations/entities";
+import {
+	ArtistRole,
+	AudioQuality,
+	EntityType,
+	ImageQuality,
+	Language,
+} from "@/types/entity";
+
+describe("parseEntity", () => {
+	it("returns data on successful parse", () => {
+		const data = {
+			quality: ImageQuality.HIGH,
+			url: "https://example.com/img.jpg",
+		};
+		const result = parseEntity(ImageSchema, data);
+		expect(result).not.toBeNull();
+		expect(result?.quality).toBe(ImageQuality.HIGH);
+	});
+
+	it("returns null on failed parse", () => {
+		const data = { quality: "invalid" };
+		const result = parseEntity(ImageSchema, data);
+		expect(result).toBeNull();
+	});
+
+	it("handles null input", () => {
+		const result = parseEntity(ImageSchema, null);
+		expect(result).toBeNull();
+	});
+
+	it("handles undefined input", () => {
+		const result = parseEntity(ImageSchema, undefined);
+		expect(result).toBeNull();
+	});
+});
+
+describe("ImageSchema", () => {
+	it("validates valid image", () => {
+		const data = {
+			quality: ImageQuality.HIGH,
+			url: "https://example.com/img.jpg",
+		};
+		expect(ImageSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("rejects invalid quality", () => {
+		const data = { quality: "invalid", url: "https://example.com/img.jpg" };
+		expect(ImageSchema.safeParse(data).success).toBe(false);
+	});
+
+	it("rejects invalid URL", () => {
+		const data = { quality: ImageQuality.HIGH, url: "not-a-url" };
+		expect(ImageSchema.safeParse(data).success).toBe(false);
+	});
+});
+
+describe("DownloadUrlSchema", () => {
+	it("validates valid download URL", () => {
+		const data = {
+			quality: AudioQuality.VERY_HIGH,
+			url: "https://example.com/audio.mp3",
+		};
+		expect(DownloadUrlSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("rejects invalid quality", () => {
+		const data = { quality: "invalid", url: "https://example.com/audio.mp3" };
+		expect(DownloadUrlSchema.safeParse(data).success).toBe(false);
+	});
+});
+
+describe("ArtistMiniSchema", () => {
+	it("validates valid artist", () => {
+		const data = {
+			id: "artist1",
+			name: "Test Artist",
+			role: ArtistRole.SINGER,
+			type: EntityType.ARTIST,
+			image: [],
+			url: "https://example.com/artist",
+		};
+		expect(ArtistMiniSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("accepts string role", () => {
+		const data = {
+			id: "artist1",
+			name: "Test Artist",
+			role: "singer",
+			type: "artist",
+			image: [],
+			url: "https://example.com/artist",
+		};
+		expect(ArtistMiniSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("rejects missing required fields", () => {
+		const data = { id: "artist1" };
+		expect(ArtistMiniSchema.safeParse(data).success).toBe(false);
+	});
+});
+
+describe("AlbumMiniSchema", () => {
+	it("validates valid album", () => {
+		const data = {
+			id: "album1",
+			name: "Test Album",
+			url: "https://example.com/album",
+		};
+		expect(AlbumMiniSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("allows null values", () => {
+		const data = { id: null, name: null, url: null };
+		expect(AlbumMiniSchema.safeParse(data).success).toBe(true);
+	});
+});
+
+describe("DetailedSongSchema", () => {
+	it("validates complete song data", () => {
+		const data = {
+			id: "song1",
+			name: "Test Song",
+			type: "song",
+			year: "2024",
+			releaseDate: "2024-01-01",
+			duration: 180,
+			label: "Test",
+			explicitContent: false,
+			playCount: 1000,
+			language: Language.HINDI,
+			hasLyrics: true,
+			lyricsId: "lyrics1",
+			url: "https://example.com/song",
+			copyright: "2024 Test",
+			album: { id: "album1", name: "Album", url: "https://example.com/album" },
+			artists: {
+				primary: [
+					{
+						id: "a1",
+						name: "Artist",
+						role: "singer",
+						type: "artist",
+						image: [],
+						url: "https://example.com/a",
+					},
+				],
+				featured: [],
+				all: [],
+			},
+			image: [
+				{ quality: ImageQuality.HIGH, url: "https://example.com/img.jpg" },
+			],
+			downloadUrl: [
+				{
+					quality: AudioQuality.VERY_HIGH,
+					url: "https://example.com/audio.mp3",
+				},
+			],
+		};
+		expect(DetailedSongSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("allows nullable fields to be null", () => {
+		const data = {
+			id: "song1",
+			name: "Test Song",
+			type: "song",
+			year: null,
+			releaseDate: null,
+			duration: null,
+			label: null,
+			explicitContent: false,
+			playCount: null,
+			language: Language.HINDI,
+			hasLyrics: false,
+			lyricsId: null,
+			url: "https://example.com/song",
+			copyright: null,
+			album: { id: null, name: null, url: null },
+			artists: { primary: [], featured: [], all: [] },
+			image: [],
+			downloadUrl: [],
+		};
+		expect(DetailedSongSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("rejects missing required fields", () => {
+		const data = { id: "song1" };
+		expect(DetailedSongSchema.safeParse(data).success).toBe(false);
+	});
+});
+
+describe("DetailedAlbumSchema", () => {
+	it("validates complete album data", () => {
+		const data = {
+			id: "album1",
+			name: "Test Album",
+			description: "Album description",
+			year: 2024,
+			type: EntityType.ALBUM,
+			playCount: 1000,
+			language: Language.HINDI,
+			explicitContent: false,
+			artists: { primary: [], featured: [], all: [] },
+			songCount: 10,
+			url: "https://example.com/album",
+			image: [],
+			songs: [],
+		};
+		expect(DetailedAlbumSchema.safeParse(data).success).toBe(true);
+	});
+});
+
+describe("DetailedArtistSchema", () => {
+	it("validates minimal artist data", () => {
+		const data = {
+			id: "artist1",
+			name: "Test Artist",
+			url: "https://example.com/artist",
+			type: EntityType.ARTIST,
+			image: [],
+			followerCount: null,
+			fanCount: null,
+			isVerified: null,
+			dominantLanguage: null,
+			dominantType: null,
+			bio: null,
+			dob: null,
+			fb: null,
+			twitter: null,
+			wiki: null,
+			availableLanguages: [],
+			isRadioPresent: null,
+			topSongs: null,
+			topAlbums: null,
+			singles: null,
+			similarArtists: null,
+		};
+		expect(DetailedArtistSchema.safeParse(data).success).toBe(true);
+	});
+});
+
+describe("DetailedPlaylistSchema", () => {
+	it("validates complete playlist data", () => {
+		const data = {
+			id: "playlist1",
+			name: "Test Playlist",
+			description: "Playlist description",
+			year: 2024,
+			type: EntityType.PLAYLIST,
+			playCount: 100,
+			language: Language.HINDI,
+			explicitContent: false,
+			songCount: 10,
+			url: "https://example.com/playlist",
+			image: [],
+			songs: [],
+			artists: [],
+		};
+		expect(DetailedPlaylistSchema.safeParse(data).success).toBe(true);
+	});
+});
+
+describe("LocalPlaylistSchema", () => {
+	it("validates playlist with songs", () => {
+		const data = {
+			id: "playlist1",
+			name: "My Playlist",
+			songs: [],
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		};
+		expect(LocalPlaylistSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("rejects empty name", () => {
+		const data = {
+			id: "playlist1",
+			name: "",
+			songs: [],
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		};
+		expect(LocalPlaylistSchema.safeParse(data).success).toBe(false);
+	});
+});
+
+describe("createPaginatedResponseSchema", () => {
+	it("validates paginated response", () => {
+		const data = {
+			results: [1, 2, 3],
+			total: 100,
+			start: 0,
+			count: 10,
+		};
+		const schema = createPaginatedResponseSchema(z.number());
+		expect(schema.safeParse(data).success).toBe(true);
+	});
+});
+
+describe("SearchResponseSchema", () => {
+	it("validates complete search response", () => {
+		const data = {
+			songs: { results: [], position: 1 },
+			albums: { results: [], position: 2 },
+			artists: { results: [], position: 3 },
+			playlists: { results: [], position: 4 },
+		};
+		expect(SearchResponseSchema.safeParse(data).success).toBe(true);
+	});
+
+	it("allows missing optional fields", () => {
+		const data = {
+			songs: { results: [], position: 1 },
+			albums: { results: [], position: 2 },
+			artists: { results: [], position: 3 },
+			playlists: { results: [], position: 4 },
+		};
+		expect(SearchResponseSchema.safeParse(data).success).toBe(true);
+	});
+});

--- a/app/album/loading.tsx
+++ b/app/album/loading.tsx
@@ -9,7 +9,7 @@ export function AlbumPageLoading() {
 				<CardContent className="p-6">
 					<div className="flex flex-col md:flex-row gap-6">
 						{/* Album Art Skeleton */}
-						<Skeleton className="relative aspect-square w-full md:w-64 flex-shrink-0 rounded-lg" />
+						<Skeleton className="relative aspect-square w-full md:w-64 shrink-0 rounded-lg" />
 
 						{/* Album Details Skeleton */}
 						<div className="flex-1 space-y-4">

--- a/app/artist/_components/ArtistHeaderCard.tsx
+++ b/app/artist/_components/ArtistHeaderCard.tsx
@@ -21,7 +21,7 @@ export function ArtistHeaderCard({ artist }: ArtistHeaderCardProps) {
 		<Card>
 			<CardContent className="p-6">
 				<div className="flex flex-col gap-6 md:flex-row">
-					<div className="relative aspect-square w-full flex-shrink-0 md:w-64">
+					<div className="relative aspect-square w-full shrink-0 md:w-64">
 						<ProgressiveImage
 							images={artist.image}
 							alt={artist.name}

--- a/app/artist/_components/ArtistPageLoading.tsx
+++ b/app/artist/_components/ArtistPageLoading.tsx
@@ -8,7 +8,7 @@ export function ArtistPageLoading() {
 			<Card>
 				<CardContent className="p-6">
 					<div className="flex flex-col gap-6 md:flex-row">
-						<Skeleton className="relative aspect-square w-full flex-shrink-0 rounded-full md:w-64" />
+						<Skeleton className="relative aspect-square w-full shrink-0 rounded-full md:w-64" />
 						<div className="flex-1 space-y-4">
 							<div className="space-y-2">
 								<Skeleton className="h-6 w-16" />

--- a/app/auth/loading.tsx
+++ b/app/auth/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react";
+
+export default function Loading() {
+	return (
+		<div className="flex items-center justify-center pt-8">
+			<Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+		</div>
+	);
+}

--- a/app/downloads/loading.tsx
+++ b/app/downloads/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react";
+
+export default function Loading() {
+	return (
+		<div className="container mx-auto px-4 py-4 md:py-8 flex justify-center">
+			<Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+		</div>
+	);
+}

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { ErrorBoundary } from "@/components/common/error-boundary";
-import { Button } from "@/components/ui/button";
 import { OfflineSongsList } from "@/components/offline/offline-songs-list";
 import { StorageInfo } from "@/components/offline/storage-info";
+import { Button } from "@/components/ui/button";
 import { useCachedSongs } from "@/hooks/cache";
 
 function DownloadsPageContent() {

--- a/app/downloads/page.tsx
+++ b/app/downloads/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ErrorBoundary } from "@/components/common/error-boundary";
+import { Button } from "@/components/ui/button";
 import { OfflineSongsList } from "@/components/offline/offline-songs-list";
 import { StorageInfo } from "@/components/offline/storage-info";
 import { useCachedSongs } from "@/hooks/cache";
@@ -26,4 +28,20 @@ function DownloadsPageContent() {
 	);
 }
 
-export default DownloadsPageContent;
+export default function DownloadsPage() {
+	return (
+		<ErrorBoundary
+			context="DownloadsPage"
+			fallback={({ resetError }) => (
+				<div className="container mx-auto px-4 py-4 md:py-8 flex flex-col items-center justify-center min-h-[50vh] space-y-4">
+					<p className="text-muted-foreground">
+						Failed to load downloads. Please try again.
+					</p>
+					<Button onClick={resetError}>Try Again</Button>
+				</div>
+			)}
+		>
+			<DownloadsPageContent />
+		</ErrorBoundary>
+	);
+}

--- a/app/favorites/loading.tsx
+++ b/app/favorites/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react";
+
+export default function Loading() {
+	return (
+		<div className="container mx-auto py-6 px-4 sm:px-6 max-w-7xl flex justify-center min-h-[50vh]">
+			<Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+		</div>
+	);
+}

--- a/app/favorites/page.tsx
+++ b/app/favorites/page.tsx
@@ -2,8 +2,8 @@
 
 import { Heart, Loader2 } from "lucide-react";
 import { ErrorBoundary } from "@/components/common/error-boundary";
-import { Button } from "@/components/ui/button";
 import { SongsList } from "@/components/songs-list";
+import { Button } from "@/components/ui/button";
 import { useSongs } from "@/hooks/data/queries";
 import { useFavorites } from "@/hooks/use-store";
 import { useStoreHydrated } from "@/hooks/use-store-hydrated";

--- a/app/favorites/page.tsx
+++ b/app/favorites/page.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { Heart, Loader2 } from "lucide-react";
+import { ErrorBoundary } from "@/components/common/error-boundary";
+import { Button } from "@/components/ui/button";
 import { SongsList } from "@/components/songs-list";
 import { useSongs } from "@/hooks/data/queries";
 import { useFavorites } from "@/hooks/use-store";
 import { useStoreHydrated } from "@/hooks/use-store-hydrated";
 import { detailedSongToSong } from "@/lib/utils";
 
-export default function FavoritesPage() {
+function FavoritesContent() {
 	const isHydrated = useStoreHydrated();
 	const { favoriteIds } = useFavorites();
 
@@ -61,5 +63,23 @@ export default function FavoritesPage() {
 				</div>
 			) : null}
 		</div>
+	);
+}
+
+export default function FavoritesPage() {
+	return (
+		<ErrorBoundary
+			context="FavoritesPage"
+			fallback={({ resetError }) => (
+				<div className="container mx-auto py-6 px-4 sm:px-6 max-w-7xl flex flex-col items-center justify-center min-h-[50vh] space-y-4">
+					<p className="text-muted-foreground">
+						Failed to load favorites. Please try again.
+					</p>
+					<Button onClick={resetError}>Try Again</Button>
+				</div>
+			)}
+		>
+			<FavoritesContent />
+		</ErrorBoundary>
 	);
 }

--- a/app/library/_components/LibrarySongItem.tsx
+++ b/app/library/_components/LibrarySongItem.tsx
@@ -17,7 +17,7 @@ export function LibrarySongItem({ song, onClick }: LibrarySongItemProps) {
 			onClick={onClick}
 		>
 			{song.image && song.image.length > 0 ? (
-				<div className="relative h-10 w-10 flex-shrink-0">
+				<div className="relative h-10 w-10 shrink-0">
 					<Image
 						src={song.image[0]?.url || song.image[1]?.url || ""}
 						alt={song.name}
@@ -27,7 +27,7 @@ export function LibrarySongItem({ song, onClick }: LibrarySongItemProps) {
 					/>
 				</div>
 			) : (
-				<div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded bg-muted">
+				<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded bg-muted">
 					<Music className="h-5 w-5 text-muted-foreground" />
 				</div>
 			)}

--- a/app/library/loading.tsx
+++ b/app/library/loading.tsx
@@ -1,0 +1,9 @@
+import { Loader2 } from "lucide-react";
+
+export default function Loading() {
+	return (
+		<div className="container mx-auto px-4 py-8 flex justify-center">
+			<Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+		</div>
+	);
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { Home, Library } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+	return (
+		<div className="flex flex-col items-center justify-center min-h-screen p-8 text-center">
+			<h1 className="text-6xl font-bold mb-4">404</h1>
+			<h2 className="text-2xl font-semibold mb-2">Page Not Found</h2>
+			<p className="text-muted-foreground mb-8 max-w-md">
+				The page you are looking for does not exist or has been moved.
+			</p>
+			<div className="flex gap-4">
+				<Button asChild>
+					<Link href="/" className="flex items-center gap-2">
+						<Home className="h-4 w-4" />
+						Go Home
+					</Link>
+				</Button>
+				<Button variant="outline" asChild>
+					<Link href="/library" className="flex items-center gap-2">
+						<Library className="h-4 w-4" />
+						Library
+					</Link>
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { Home, Library } from "lucide-react";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
 export default function NotFound() {

--- a/app/playlist/client.tsx
+++ b/app/playlist/client.tsx
@@ -45,7 +45,7 @@ export function Client() {
 					<Card>
 						<CardContent className="p-4 md:p-6">
 							<div className="flex flex-col gap-4 md:gap-6 md:flex-row">
-								<div className="relative aspect-square w-full flex-shrink-0 md:w-64">
+								<div className="relative aspect-square w-full shrink-0 md:w-64">
 									<ProgressiveImage
 										images={playlist.image}
 										alt={playlist.name}

--- a/app/playlist/loading.tsx
+++ b/app/playlist/loading.tsx
@@ -9,7 +9,7 @@ export function PlaylistPageLoading() {
 				<CardContent className="p-6">
 					<div className="flex flex-col md:flex-row gap-6">
 						{/* Playlist Cover Skeleton */}
-						<Skeleton className="relative aspect-square w-full md:w-64 flex-shrink-0 rounded-lg" />
+						<Skeleton className="relative aspect-square w-full md:w-64 shrink-0 rounded-lg" />
 
 						{/* Playlist Details Skeleton */}
 						<div className="flex-1 space-y-4">

--- a/app/song/loading.tsx
+++ b/app/song/loading.tsx
@@ -10,7 +10,7 @@ export function SongPageLoading() {
 				<CardContent className="p-6">
 					<div className="flex flex-col md:flex-row gap-6">
 						{/* Album Art Skeleton */}
-						<Skeleton className="w-full md:w-64 aspect-square rounded-lg flex-shrink-0" />
+						<Skeleton className="w-full md:w-64 aspect-square rounded-lg shrink-0" />
 
 						{/* Song Details Skeleton */}
 						<div className="flex-1 space-y-4">

--- a/components/app-navigation/NavigationActions.tsx
+++ b/components/app-navigation/NavigationActions.tsx
@@ -16,7 +16,7 @@ export function NavigationActions() {
 						variant="outline"
 						size="sm"
 						onClick={promptInstall}
-						className="flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-primary"
+						className="shrink-0 focus:outline-none focus:ring-2 focus:ring-primary"
 						aria-label="Install app"
 					>
 						<Smartphone className="h-4 w-4" aria-hidden="true" />
@@ -27,7 +27,7 @@ export function NavigationActions() {
 				</motion.div>
 			)}
 
-			<div className="w-[38px] flex-shrink-0 sm:w-auto">
+			<div className="w-[38px] shrink-0 sm:w-auto">
 				<NavigationAuthButton />
 			</div>
 

--- a/components/app-navigation/NavigationBrand.tsx
+++ b/components/app-navigation/NavigationBrand.tsx
@@ -5,7 +5,7 @@ export function NavigationBrand() {
 	return (
 		<Link
 			href="/"
-			className="flex flex-shrink-0 items-center gap-2 rounded font-semibold text-lg transition-opacity duration-200 hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
+			className="flex shrink-0 items-center gap-2 rounded font-semibold text-lg transition-opacity duration-200 hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
 			aria-label="Music App Home"
 		>
 			<Music className="h-6 w-6" />

--- a/components/app-navigation/NavigationLinks.tsx
+++ b/components/app-navigation/NavigationLinks.tsx
@@ -17,7 +17,7 @@ function NavigationLink({
 			<Button
 				variant="ghost"
 				size="sm"
-				className="flex-shrink-0 focus:outline-none focus:ring-2 focus:ring-primary"
+				className="shrink-0 focus:outline-none focus:ring-2 focus:ring-primary"
 				aria-label={label}
 			>
 				<Icon className="h-4 w-4" aria-hidden="true" />

--- a/components/app-navigation/NavigationStatus.tsx
+++ b/components/app-navigation/NavigationStatus.tsx
@@ -6,17 +6,14 @@ interface NavigationStatusProps {
 
 export function NavigationStatus({ isOffline }: NavigationStatusProps) {
 	return (
-		<div className="flex flex-shrink-0 items-center gap-2 rounded-md border bg-card px-3 py-1.5">
+		<div className="flex shrink-0 items-center gap-2 rounded-md border bg-card px-3 py-1.5">
 			{isOffline ? (
 				<WifiOff
-					className="h-4 w-4 flex-shrink-0 text-orange-500"
+					className="h-4 w-4 shrink-0 text-orange-500"
 					aria-hidden="true"
 				/>
 			) : (
-				<Wifi
-					className="h-4 w-4 flex-shrink-0 text-green-500"
-					aria-hidden="true"
-				/>
+				<Wifi className="h-4 w-4 shrink-0 text-green-500" aria-hidden="true" />
 			)}
 			<span className="hidden whitespace-nowrap text-sm font-medium sm:inline">
 				{isOffline ? "Offline" : "Online"}

--- a/components/audio-player.tsx
+++ b/components/audio-player.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/hooks/use-store";
 import { getDownloadedSongBlob } from "@/lib/downloads/storage";
 import { useAppStore } from "@/lib/store";
+import * as selectors from "@/lib/store/selectors";
 import { DesktopLayout } from "./player/desktop-layout";
 import { MobileLayout } from "./player/mobile-layout";
 import { PlayerContainer } from "./player/player-container";
@@ -38,7 +39,7 @@ export function AudioPlayer() {
 	const duration = useDuration();
 	const queue = useQueueSongs();
 	const queueIndex = useQueueIndex();
-	const downloadedSongIds = useAppStore((state) => state.downloadedSongIds);
+	const downloadedSongIds = useAppStore(selectors.selectDownloadedSongIds);
 
 	const audioRef = useRef<HTMLAudioElement>(null);
 

--- a/components/breadcrumb-nav.tsx
+++ b/components/breadcrumb-nav.tsx
@@ -102,7 +102,7 @@ export function BreadcrumbNav() {
 					<motion.div
 						whileHover={{ x: -3 }}
 						whileTap={{ scale: 0.95 }}
-						className="flex-shrink-0"
+						className="shrink-0"
 					>
 						<Button
 							variant="ghost"
@@ -116,7 +116,7 @@ export function BreadcrumbNav() {
 					</motion.div>
 
 					{/* Divider */}
-					<div className="w-px h-6 bg-border flex-shrink-0" />
+					<div className="w-px h-6 bg-border shrink-0" />
 
 					{/* Breadcrumbs */}
 					<Breadcrumb className="flex-1 min-w-0">
@@ -124,19 +124,19 @@ export function BreadcrumbNav() {
 							<BreadcrumbItem>
 								<BreadcrumbLink asChild>
 									<Link href="/" className="flex items-center gap-1.5">
-										<Home className="h-3.5 w-3.5 flex-shrink-0" />
+										<Home className="h-3.5 w-3.5 shrink-0" />
 										<span className="truncate">Home</span>
 									</Link>
 								</BreadcrumbLink>
 							</BreadcrumbItem>
 							{breadcrumbs.map((crumb: BreadcrumbSegment) => (
 								<div key={crumb.href} className="flex items-center gap-1.5">
-									<BreadcrumbSeparator className="flex-shrink-0" />
+									<BreadcrumbSeparator className="shrink-0" />
 									<BreadcrumbItem>
 										{crumb.isCurrentPage ? (
 											<BreadcrumbPage className="flex items-center gap-1.5 truncate">
 												{crumb.icon && (
-													<span className="flex-shrink-0">{crumb.icon}</span>
+													<span className="shrink-0">{crumb.icon}</span>
 												)}
 												<span className="truncate">{crumb.label}</span>
 											</BreadcrumbPage>
@@ -147,7 +147,7 @@ export function BreadcrumbNav() {
 													className="flex items-center gap-1.5 truncate"
 												>
 													{crumb.icon && (
-														<span className="flex-shrink-0">{crumb.icon}</span>
+														<span className="shrink-0">{crumb.icon}</span>
 													)}
 													<span className="truncate">{crumb.label}</span>
 												</Link>

--- a/components/common/error-boundary.tsx
+++ b/components/common/error-boundary.tsx
@@ -193,7 +193,7 @@ export class ErrorBoundary extends React.Component<
 			const hasRetriesLeft = this.state.retryCount < maxRetries;
 
 			return (
-				<div className="flex flex-col items-center justify-center min-h-[400px] p-8 text-center">
+				<div className="flex flex-col items-center justify-center min-h-100 p-8 text-center">
 					<AlertTriangle className="h-12 w-12 text-destructive mb-4" />
 					<h2 className="text-xl font-semibold mb-2">{title}</h2>
 					<p className="text-muted-foreground mb-4 max-w-md">{message}</p>

--- a/components/entity/query-param-detail-shell.tsx
+++ b/components/entity/query-param-detail-shell.tsx
@@ -6,7 +6,7 @@ interface QueryParamDetailShellProps {
 	entityLabel: string;
 	isOffline: boolean;
 	isPending: boolean;
-	error?: unknown;
+	error?: Error | null;
 	hasData: boolean;
 	loadingFallback: ReactNode;
 	children: ReactNode;

--- a/components/player/song-info.tsx
+++ b/components/player/song-info.tsx
@@ -14,7 +14,7 @@ export const SongInfo = memo(function SongInfo({ currentSong }: SongInfoProps) {
 	if (!currentSong) {
 		return (
 			<div className="flex items-center gap-4 min-w-0 w-72">
-				<div className="relative h-16 w-16 flex-shrink-0 bg-muted rounded flex items-center justify-center">
+				<div className="relative h-16 w-16 shrink-0 bg-muted rounded flex items-center justify-center">
 					<div className="h-8 w-8 bg-muted-foreground/20 rounded" />
 				</div>
 				<div className="min-w-0 flex-1">
@@ -38,7 +38,7 @@ export const SongInfo = memo(function SongInfo({ currentSong }: SongInfoProps) {
 			transition={{ duration: 0.3 }}
 		>
 			{currentSong.image && currentSong.image.length > 0 && (
-				<div className="relative h-16 w-16 flex-shrink-0">
+				<div className="relative h-16 w-16 shrink-0">
 					<ProgressiveImage
 						images={currentSong.image}
 						alt={currentSong.name}

--- a/components/states/page-states.tsx
+++ b/components/states/page-states.tsx
@@ -34,7 +34,7 @@ interface PageStatesProps<T> {
 
 const DefaultLoadingState = memo(function DefaultLoadingState() {
 	return (
-		<div className="flex flex-col items-center justify-center min-h-[400px] gap-4">
+		<div className="flex flex-col items-center justify-center min-h-100 gap-4">
 			<Loader2 className="h-8 w-8 animate-spin text-primary" />
 			<p className="text-muted-foreground">Loading...</p>
 		</div>
@@ -47,7 +47,7 @@ const DefaultErrorState = memo(function DefaultErrorState({
 	error: Error | null;
 }) {
 	return (
-		<div className="flex flex-col items-center justify-center min-h-[400px] gap-4 text-destructive">
+		<div className="flex flex-col items-center justify-center min-h-100 gap-4 text-destructive">
 			<AlertCircle className="h-8 w-8" />
 			<div className="text-center">
 				<p className="font-semibold">Error loading content</p>
@@ -59,7 +59,7 @@ const DefaultErrorState = memo(function DefaultErrorState({
 
 const DefaultEmptyState = memo(function DefaultEmptyState() {
 	return (
-		<div className="flex flex-col items-center justify-center min-h-[400px] gap-4 text-muted-foreground">
+		<div className="flex flex-col items-center justify-center min-h-100 gap-4 text-muted-foreground">
 			<p className="text-lg">No content available</p>
 		</div>
 	);
@@ -67,7 +67,7 @@ const DefaultEmptyState = memo(function DefaultEmptyState() {
 
 const DefaultOfflineState = memo(function DefaultOfflineState() {
 	return (
-		<div className="flex flex-col items-center justify-center min-h-[400px] gap-4 text-muted-foreground">
+		<div className="flex flex-col items-center justify-center min-h-100 gap-4 text-muted-foreground">
 			<WifiOff className="h-8 w-8" />
 			<div className="text-center">
 				<p className="font-semibold">Offline Mode</p>

--- a/hooks/audio/use-audio-event-listeners.ts
+++ b/hooks/audio/use-audio-event-listeners.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { type RefObject, useEffect, useRef } from "react";
 import { logAudioError } from "@/lib/utils/audio-error";
 import {

--- a/hooks/audio/use-audio-playback.ts
+++ b/hooks/audio/use-audio-playback.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useRef } from "react";
 import { logAudioError } from "@/lib/utils/audio-error";
 import { normalizeError } from "@/lib/utils/normalize-error";

--- a/hooks/audio/use-audio-seeking.ts
+++ b/hooks/audio/use-audio-seeking.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect } from "react";
 import { useCurrentTime } from "@/hooks/use-store";
 import { useAppStore } from "@/lib/store";

--- a/hooks/audio/use-audio-settings.ts
+++ b/hooks/audio/use-audio-settings.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect } from "react";
 
 interface UseAudioSettingsProps {

--- a/hooks/audio/use-audio-source.ts
+++ b/hooks/audio/use-audio-source.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useRef } from "react";
 import {
 	PREFERRED_AUDIO_QUALITY,

--- a/hooks/audio/use-media-session.ts
+++ b/hooks/audio/use-media-session.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useRef } from "react";
 import { logAudioError } from "@/lib/utils/audio-error";
 import { SEEK_OFFSET_SECONDS, type UseMediaSessionProps } from "@/types/player";

--- a/hooks/data/queries.ts
+++ b/hooks/data/queries.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import type { UseQueryOptions } from "@tanstack/react-query";
 import { useQuery } from "@tanstack/react-query";
 import {

--- a/hooks/data/queries.ts
+++ b/hooks/data/queries.ts
@@ -42,9 +42,9 @@ function useConfiguredQuery<T>(
 ) {
 	return useQuery({
 		...baseOptions,
-		...(options as QueryHookOptions<T> | undefined),
 		enabled,
-	});
+		...options,
+	} as UseQueryOptions<T, Error, T>);
 }
 
 export function useSong(
@@ -67,11 +67,7 @@ export function useSongs(
 	options?: QueryHookOptions<DetailedSong[]>,
 ) {
 	return useConfiguredQuery(
-		songsQueryOptions(ids) as UseQueryOptions<
-			DetailedSong[],
-			Error,
-			DetailedSong[]
-		>,
+		songsQueryOptions(ids) as UseQueryOptions<DetailedSong[], Error>,
 		ids.length > 0 && options?.enabled !== false,
 		options,
 	);
@@ -82,11 +78,7 @@ export function useAlbum(
 	options?: QueryHookOptions<DetailedAlbum>,
 ) {
 	return useConfiguredQuery(
-		albumQueryOptions(id) as UseQueryOptions<
-			DetailedAlbum,
-			Error,
-			DetailedAlbum
-		>,
+		albumQueryOptions(id) as UseQueryOptions<DetailedAlbum, Error>,
 		!!id && options?.enabled !== false,
 		options,
 	);
@@ -97,11 +89,7 @@ export function useArtist(
 	options?: QueryHookOptions<DetailedArtist>,
 ) {
 	return useConfiguredQuery(
-		artistQueryOptions(id) as UseQueryOptions<
-			DetailedArtist,
-			Error,
-			DetailedArtist
-		>,
+		artistQueryOptions(id) as UseQueryOptions<DetailedArtist, Error>,
 		!!id && options?.enabled !== false,
 		options,
 	);
@@ -112,11 +100,7 @@ export function usePlaylist(
 	options?: QueryHookOptions<DetailedPlaylist>,
 ) {
 	return useConfiguredQuery(
-		playlistQueryOptions(id) as UseQueryOptions<
-			DetailedPlaylist,
-			Error,
-			DetailedPlaylist
-		>,
+		playlistQueryOptions(id) as UseQueryOptions<DetailedPlaylist, Error>,
 		!!id && options?.enabled !== false,
 		options,
 	);
@@ -127,11 +111,7 @@ export function useGlobalSearch(
 	options?: QueryHookOptions<SearchResponse>,
 ) {
 	return useConfiguredQuery(
-		globalSearchQueryOptions(query) as UseQueryOptions<
-			SearchResponse,
-			Error,
-			SearchResponse
-		>,
+		globalSearchQueryOptions(query) as UseQueryOptions<SearchResponse, Error>,
 		!!query && options?.enabled !== false,
 		options,
 	);
@@ -148,8 +128,7 @@ export function useSearchSongs(
 	return useConfiguredQuery(
 		searchSongsQueryOptions(query, limit) as UseQueryOptions<
 			{ total: number; results: DetailedSong[] },
-			Error,
-			{ total: number; results: DetailedSong[] }
+			Error
 		>,
 		!!query && options?.enabled !== false,
 		options,
@@ -167,8 +146,7 @@ export function useSearchAlbums(
 	return useConfiguredQuery(
 		searchAlbumsQueryOptions(query, limit) as UseQueryOptions<
 			{ total: number; results: AlbumSearchResult[] },
-			Error,
-			{ total: number; results: AlbumSearchResult[] }
+			Error
 		>,
 		!!query && options?.enabled !== false,
 		options,
@@ -186,8 +164,7 @@ export function useSearchArtists(
 	return useConfiguredQuery(
 		searchArtistsQueryOptions(query, limit) as UseQueryOptions<
 			{ total: number; results: ArtistSearchResult[] },
-			Error,
-			{ total: number; results: ArtistSearchResult[] }
+			Error
 		>,
 		!!query && options?.enabled !== false,
 		options,
@@ -208,8 +185,7 @@ export function useSearchPlaylists(
 	return useConfiguredQuery(
 		searchPlaylistsQueryOptions(query, limit) as UseQueryOptions<
 			{ total: number; results: PlaylistSearchResult[] },
-			Error,
-			{ total: number; results: PlaylistSearchResult[] }
+			Error
 		>,
 		!!query && options?.enabled !== false,
 		options,
@@ -227,8 +203,7 @@ export function useSongSuggestions(
 	return useConfiguredQuery(
 		songSuggestionsQueryOptions(id, limit) as UseQueryOptions<
 			DetailedSong[],
-			Error,
-			DetailedSong[]
+			Error
 		>,
 		!!id && options?.enabled !== false,
 		options,
@@ -247,8 +222,7 @@ export function useArtistSongs(
 	return useConfiguredQuery(
 		artistSongsQueryOptions(id, sortBy, sortOrder) as UseQueryOptions<
 			{ total: number; songs: DetailedSong[] },
-			Error,
-			{ total: number; songs: DetailedSong[] }
+			Error
 		>,
 		!!id && options?.enabled !== false,
 		options,
@@ -267,8 +241,7 @@ export function useArtistAlbums(
 	return useConfiguredQuery(
 		artistAlbumsQueryOptions(id, sortBy, sortOrder) as UseQueryOptions<
 			{ total: number; albums: DetailedAlbum[] },
-			Error,
-			{ total: number; albums: DetailedAlbum[] }
+			Error
 		>,
 		!!id && options?.enabled !== false,
 		options,

--- a/hooks/data/use-detailed-song.ts
+++ b/hooks/data/use-detailed-song.ts
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * Lazy Load Detailed Song Hook
  * Fetches full song details when needed (e.g., in action menus)

--- a/hooks/data/use-search-queries.ts
+++ b/hooks/data/use-search-queries.ts
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * Parallel Search Queries Orchestration Hook
  * Fetches songs/albums/artists/playlists in parallel

--- a/hooks/network/use-network-detection.ts
+++ b/hooks/network/use-network-detection.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { useIsOffline } from "./use-is-offline";

--- a/hooks/playback/use-playback-speed.ts
+++ b/hooks/playback/use-playback-speed.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useCallback } from "react";
 import { usePlaybackSpeedValue } from "@/hooks/use-store";
 import { useAppStore } from "@/lib/store";

--- a/hooks/playback/use-sleep-timer.ts
+++ b/hooks/playback/use-sleep-timer.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAppStore } from "@/lib/store";
 

--- a/hooks/player/use-offline-player.ts
+++ b/hooks/player/use-offline-player.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { toast } from "sonner";
 import { useIsOffline } from "@/hooks/network/use-is-offline";
 import { useAppStore } from "@/hooks/use-store";

--- a/hooks/player/use-offline-skip.ts
+++ b/hooks/player/use-offline-skip.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect } from "react";
 import { toast } from "sonner";
 import type { UseOfflineSkipProps } from "@/types/player";

--- a/hooks/player/use-song-actions.ts
+++ b/hooks/player/use-song-actions.ts
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * Song Actions Hook
  * Centralizes song action logic (queue, playlist, favorites)

--- a/hooks/search/use-search-history.ts
+++ b/hooks/search/use-search-history.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useCallback, useEffect, useState } from "react";
 
 const SEARCH_HISTORY_KEY = "music-app-search-history";

--- a/hooks/search/use-search-suggestions.ts
+++ b/hooks/search/use-search-suggestions.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useRef, useState } from "react";
 import { searchMusic } from "@/lib/api";
 

--- a/hooks/ui/use-analytics.ts
+++ b/hooks/ui/use-analytics.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useCallback, useEffect, useRef } from "react";
 
 type AnalyticsEvent =

--- a/hooks/ui/use-analytics.ts
+++ b/hooks/ui/use-analytics.ts
@@ -38,10 +38,10 @@ function generateSessionId(): string {
 function getStoredUserId(): string {
 	if (typeof window === "undefined") return "anonymous";
 	const key = "analytics_user_id";
-	let userId = localStorage.getItem(key);
+	let userId = sessionStorage.getItem(key);
 	if (!userId) {
 		userId = `user_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
-		localStorage.setItem(key, userId);
+		sessionStorage.setItem(key, userId);
 	}
 	return userId;
 }

--- a/hooks/ui/use-controlled-state.ts
+++ b/hooks/ui/use-controlled-state.ts
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * useControlledState Hook
  * Manages state for controlled/uncontrolled patterns (dialog, popover, etc.)

--- a/hooks/ui/use-history-display.ts
+++ b/hooks/ui/use-history-display.ts
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * Hook for transforming history items into display format
  * Handles type-aware rendering data for songs

--- a/hooks/ui/use-keyboard-shortcuts.ts
+++ b/hooks/ui/use-keyboard-shortcuts.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useCallback, useEffect, useRef } from "react";
 import { usePlayer } from "@/hooks/use-store";
 import { useAppStore } from "@/lib/store";

--- a/hooks/ui/use-mobile.ts
+++ b/hooks/ui/use-mobile.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 
 const MOBILE_BREAKPOINT = 768;

--- a/hooks/ui/use-performance-monitor.ts
+++ b/hooks/ui/use-performance-monitor.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useCallback, useEffect, useRef } from "react";
 
 interface PerformanceMetrics {
@@ -49,7 +51,7 @@ export function usePerformanceMonitor(options: UsePerformanceMonitorOptions) {
 				`[${componentName}] Render #${renderCountRef.current} took ${duration.toFixed(2)}ms`,
 			);
 		}
-	});
+	}, [componentName, logRenders, slowRenderThreshold]);
 
 	const getMetrics = useCallback((): PerformanceMetrics => {
 		const durations = durationRef.current;

--- a/hooks/ui/use-pwa-install.ts
+++ b/hooks/ui/use-pwa-install.ts
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * PWA installation utilities
  * Manages the Web App Install Prompt and tracks installation state

--- a/hooks/ui/use-queue-drag.ts
+++ b/hooks/ui/use-queue-drag.ts
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * Unified drag-and-drop reordering hook
  * Consolidates 3 previous implementations into a single, reusable hook

--- a/hooks/use-store.ts
+++ b/hooks/use-store.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useAppStore } from "@/lib/store";
 import * as selectors from "@/lib/store/selectors";
@@ -47,15 +48,20 @@ export function useQueue() {
 }
 
 export function useFavorites() {
-	return {
-		favoriteIds: useAppStore(selectors.selectFavoriteIds),
-		isFavorite: (songId: string) => useAppStore.getState().isFavorite(songId),
-		toggleFavorite: (songId: string) =>
-			useAppStore.getState().toggleFavorite(songId),
-		addFavorite: (songId: string) => useAppStore.getState().addFavorite(songId),
-		removeFavorite: (songId: string) =>
-			useAppStore.getState().removeFavorite(songId),
-	};
+	const favoriteIds = useAppStore(selectors.selectFavoriteIds);
+	return useMemo(
+		() => ({
+			favoriteIds,
+			isFavorite: (songId: string) => useAppStore.getState().isFavorite(songId),
+			toggleFavorite: (songId: string) =>
+				useAppStore.getState().toggleFavorite(songId),
+			addFavorite: (songId: string) =>
+				useAppStore.getState().addFavorite(songId),
+			removeFavorite: (songId: string) =>
+				useAppStore.getState().removeFavorite(songId),
+		}),
+		[favoriteIds],
+	);
 }
 
 export function useIsFavorite(songId: string) {
@@ -63,37 +69,47 @@ export function useIsFavorite(songId: string) {
 }
 
 export function useHistory() {
-	return {
-		searchHistory: useAppStore(selectors.selectSearchHistory),
-		playbackHistory: useAppStore(selectors.selectPlaybackHistory),
-		visitHistory: useAppStore(selectors.selectVisitHistory),
-		addToSearchHistory: (query: string) =>
-			useAppStore.getState().addToSearchHistory(query),
-		clearSearchHistory: () => useAppStore.getState().clearSearchHistory(),
-		addToPlaybackHistory: (song: DetailedSong) =>
-			useAppStore.getState().addToPlaybackHistory(song),
-		clearPlaybackHistory: () => useAppStore.getState().clearPlaybackHistory(),
-		addToVisitHistory: (visit: EntityVisit) =>
-			useAppStore.getState().addToVisitHistory(visit),
-		clearVisitHistory: () => useAppStore.getState().clearVisitHistory(),
-	};
+	const searchHistory = useAppStore(selectors.selectSearchHistory);
+	const playbackHistory = useAppStore(selectors.selectPlaybackHistory);
+	const visitHistory = useAppStore(selectors.selectVisitHistory);
+	return useMemo(
+		() => ({
+			searchHistory,
+			playbackHistory,
+			visitHistory,
+			addToSearchHistory: (query: string) =>
+				useAppStore.getState().addToSearchHistory(query),
+			clearSearchHistory: () => useAppStore.getState().clearSearchHistory(),
+			addToPlaybackHistory: (song: DetailedSong) =>
+				useAppStore.getState().addToPlaybackHistory(song),
+			clearPlaybackHistory: () => useAppStore.getState().clearPlaybackHistory(),
+			addToVisitHistory: (visit: EntityVisit) =>
+				useAppStore.getState().addToVisitHistory(visit),
+			clearVisitHistory: () => useAppStore.getState().clearVisitHistory(),
+		}),
+		[searchHistory, playbackHistory, visitHistory],
+	);
 }
 
 export function usePlaylists() {
-	return {
-		playlists: useAppStore(selectors.selectPlaylists),
-		createPlaylist: (name: string) =>
-			useAppStore.getState().createPlaylist(name),
-		updatePlaylist: (id: string, name: string) =>
-			useAppStore.getState().updatePlaylist(id, name),
-		deletePlaylist: (id: string) => useAppStore.getState().deletePlaylist(id),
-		addSongToPlaylist: (id: string, song: DetailedSong) =>
-			useAppStore.getState().addSongToPlaylist(id, song),
-		removeSongFromPlaylist: (id: string, songId: string) =>
-			useAppStore.getState().removeSongFromPlaylist(id, songId),
-		reorderPlaylistSongs: (id: string, fromIndex: number, toIndex: number) =>
-			useAppStore.getState().reorderPlaylistSongs(id, fromIndex, toIndex),
-	};
+	const playlists = useAppStore(selectors.selectPlaylists);
+	return useMemo(
+		() => ({
+			playlists,
+			createPlaylist: (name: string) =>
+				useAppStore.getState().createPlaylist(name),
+			updatePlaylist: (id: string, name: string) =>
+				useAppStore.getState().updatePlaylist(id, name),
+			deletePlaylist: (id: string) => useAppStore.getState().deletePlaylist(id),
+			addSongToPlaylist: (id: string, song: DetailedSong) =>
+				useAppStore.getState().addSongToPlaylist(id, song),
+			removeSongFromPlaylist: (id: string, songId: string) =>
+				useAppStore.getState().removeSongFromPlaylist(id, songId),
+			reorderPlaylistSongs: (id: string, fromIndex: number, toIndex: number) =>
+				useAppStore.getState().reorderPlaylistSongs(id, fromIndex, toIndex),
+		}),
+		[playlists],
+	);
 }
 
 export function useUIState() {
@@ -106,25 +122,32 @@ export function useUIState() {
 }
 
 export function useUIActions() {
-	return {
-		setIsQueueOpen: (open: boolean) =>
-			useAppStore.getState().setIsQueueOpen(open),
-		setSleepTimer: (minutes: number | null) =>
-			useAppStore.getState().setSleepTimer(minutes),
-	};
+	return useMemo(
+		() => ({
+			setIsQueueOpen: (open: boolean) =>
+				useAppStore.getState().setIsQueueOpen(open),
+			setSleepTimer: (minutes: number | null) =>
+				useAppStore.getState().setSleepTimer(minutes),
+		}),
+		[],
+	);
 }
 
 export function useDownloads() {
-	return {
-		downloadedSongIds: useAppStore(selectors.selectDownloadedSongIds),
-		addDownloadedSong: (songId: string) =>
-			useAppStore.getState().addDownloadedSong(songId),
-		removeDownloadedSong: (songId: string) =>
-			useAppStore.getState().removeDownloadedSong(songId),
-		clearDownloadedSongs: () => useAppStore.getState().clearDownloadedSongs(),
-		isDownloaded: (songId: string) =>
-			useAppStore.getState().isDownloaded(songId),
-	};
+	const downloadedSongIds = useAppStore(selectors.selectDownloadedSongIds);
+	return useMemo(
+		() => ({
+			downloadedSongIds,
+			addDownloadedSong: (songId: string) =>
+				useAppStore.getState().addDownloadedSong(songId),
+			removeDownloadedSong: (songId: string) =>
+				useAppStore.getState().removeDownloadedSong(songId),
+			clearDownloadedSongs: () => useAppStore.getState().clearDownloadedSongs(),
+			isDownloaded: (songId: string) =>
+				useAppStore.getState().isDownloaded(songId),
+		}),
+		[downloadedSongIds],
+	);
 }
 
 export function useIsDownloaded(songId: string) {

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -17,9 +17,52 @@ const API_BASE_URL = publicConfig.NEXT_PUBLIC_API_URL;
 
 const ENTITY_ID_REGEX = /^[a-zA-Z0-9-]{5,50}$/;
 
+const DEFAULT_TIMEOUT = 30000;
+const MAX_RETRIES = 3;
+const RETRY_DELAY_BASE = 1000;
+
 function validateEntityId(id: string): void {
 	if (!ENTITY_ID_REGEX.test(id)) {
 		throw new Error(`Invalid entity ID format: ${id}`);
+	}
+}
+
+async function fetchWithRetry(
+	url: string,
+	options: RequestInit & { signal?: AbortSignal },
+	retries = MAX_RETRIES,
+): Promise<Response> {
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT);
+
+	const fetchOptions = {
+		...options,
+		signal: options.signal
+			? AbortSignal.any([options.signal, controller.signal])
+			: controller.signal,
+	};
+
+	try {
+		let lastError: Error | null = null;
+
+		for (let attempt = 0; attempt <= retries; attempt++) {
+			try {
+				const response = await fetch(url, fetchOptions);
+				clearTimeout(timeoutId);
+				return response;
+			} catch (error) {
+				lastError = error instanceof Error ? error : new Error(String(error));
+
+				if (attempt < retries) {
+					const delay = RETRY_DELAY_BASE * Math.pow(2, attempt);
+					await new Promise((resolve) => setTimeout(resolve, delay));
+				}
+			}
+		}
+
+		throw lastError;
+	} finally {
+		clearTimeout(timeoutId);
 	}
 }
 
@@ -28,9 +71,10 @@ async function fetchApi<T>(
 	errorMessage: string,
 	options?: { signal?: AbortSignal },
 ): Promise<T> {
-	const response = await fetch(url, { signal: options?.signal });
+	const response = await fetchWithRetry(url, { signal: options?.signal });
+
 	if (!response.ok) {
-		throw new Error(errorMessage);
+		throw new Error(`${errorMessage} (HTTP ${response.status})`);
 	}
 
 	const text = await response.text();
@@ -58,10 +102,12 @@ export async function searchSongs(
 	query: string,
 	page = 0,
 	limit = 10,
+	options?: { signal?: AbortSignal },
 ): Promise<PaginatedResponse<DetailedSong>> {
 	return fetchApi<PaginatedResponse<DetailedSong>>(
 		`${API_BASE_URL}/search/songs?query=${encodeURIComponent(query)}&page=${page}&limit=${limit}`,
 		"Failed to search songs",
+		options,
 	);
 }
 
@@ -69,10 +115,12 @@ export async function searchAlbums(
 	query: string,
 	page = 0,
 	limit = 10,
+	options?: { signal?: AbortSignal },
 ): Promise<PaginatedResponse<AlbumSearchResult>> {
 	return fetchApi<PaginatedResponse<AlbumSearchResult>>(
 		`${API_BASE_URL}/search/albums?query=${encodeURIComponent(query)}&page=${page}&limit=${limit}`,
 		"Failed to search albums",
+		options,
 	);
 }
 
@@ -80,10 +128,12 @@ export async function searchArtists(
 	query: string,
 	page = 0,
 	limit = 10,
+	options?: { signal?: AbortSignal },
 ): Promise<PaginatedResponse<ArtistSearchResult>> {
 	return fetchApi<PaginatedResponse<ArtistSearchResult>>(
 		`${API_BASE_URL}/search/artists?query=${encodeURIComponent(query)}&page=${page}&limit=${limit}`,
 		"Failed to search artists",
+		options,
 	);
 }
 
@@ -91,10 +141,12 @@ export async function searchPlaylists(
 	query: string,
 	page = 0,
 	limit = 10,
+	options?: { signal?: AbortSignal },
 ): Promise<PaginatedResponse<PlaylistSearchResult>> {
 	return fetchApi<PaginatedResponse<PlaylistSearchResult>>(
 		`${API_BASE_URL}/search/playlists?query=${encodeURIComponent(query)}&page=${page}&limit=${limit}`,
 		"Failed to search playlists",
+		options,
 	);
 }
 
@@ -106,21 +158,27 @@ export async function getSongById(id: string): Promise<DetailedSong[]> {
 	);
 }
 
-export async function getSongsByIds(ids: string[]): Promise<DetailedSong[]> {
+export async function getSongsByIds(
+	ids: string[],
+	options?: { signal?: AbortSignal },
+): Promise<DetailedSong[]> {
 	return fetchApi<DetailedSong[]>(
 		`${API_BASE_URL}/songs?ids=${ids.join(",")}`,
 		"Failed to fetch songs",
+		options,
 	);
 }
 
 export async function getSongSuggestions(
 	id: string,
 	limit = 10,
+	options?: { signal?: AbortSignal },
 ): Promise<DetailedSong[]> {
 	validateEntityId(id);
 	return fetchApi<DetailedSong[]>(
 		`${API_BASE_URL}/songs/${encodeURIComponent(id)}/suggestions?limit=${limit}`,
 		"Failed to fetch song suggestions",
+		options,
 	);
 }
 

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -54,7 +54,7 @@ async function fetchWithRetry(
 				lastError = error instanceof Error ? error : new Error(String(error));
 
 				if (attempt < retries) {
-					const delay = RETRY_DELAY_BASE * Math.pow(2, attempt);
+					const delay = RETRY_DELAY_BASE * 2 ** attempt;
 					await new Promise((resolve) => setTimeout(resolve, delay));
 				}
 			}
@@ -84,6 +84,11 @@ async function fetchApi<T>(
 		}
 		return value;
 	}) as ApiResponse<T>;
+
+	if (!data || typeof data !== "object") {
+		throw new Error(`${errorMessage}: Invalid response format`);
+	}
+
 	return data.data;
 }
 

--- a/lib/cache/constants.ts
+++ b/lib/cache/constants.ts
@@ -1,10 +1,25 @@
 // Cache keys for all entities
 export const CACHE_KEYS = {
 	SONGS: (id: string) => ["song", id] as const,
+	SONGS_BY_IDS: (ids: string[]) => ["songs", ...ids] as const,
 	ALBUM: (id: string) => ["album", id] as const,
 	ARTIST: (id: string) => ["artist", id] as const,
 	PLAYLIST: (id: string) => ["playlist", id] as const,
 	SEARCH: (query: string) => ["search", query] as const,
+	SEARCH_SONGS: (query: string, limit: number) =>
+		["search-songs", query, limit] as const,
+	SEARCH_ALBUMS: (query: string, limit: number) =>
+		["search-albums", query, limit] as const,
+	SEARCH_ARTISTS: (query: string, limit: number) =>
+		["search-artists", query, limit] as const,
+	SEARCH_PLAYLISTS: (query: string, limit: number) =>
+		["search-playlists", query, limit] as const,
+	SUGGESTIONS: (id: string, limit: number) =>
+		["suggestions", id, limit] as const,
+	ARTIST_SONGS: (id: string, sortBy: string, sortOrder: string) =>
+		["artist-songs", id, sortBy, sortOrder] as const,
+	ARTIST_ALBUMS: (id: string, sortBy: string, sortOrder: string) =>
+		["artist-albums", id, sortBy, sortOrder] as const,
 	DOWNLOADS: (id: string) => ["downloads", id] as const,
 	ALL_DOWNLOADS: ["downloads"] as const,
 	QUEUE: ["queue"] as const,
@@ -19,11 +34,11 @@ export const CACHE_TIMES = {
 	ALBUM: 1000 * 60 * 10, // 10 min
 	ARTIST: 1000 * 60 * 10, // 10 min
 	SEARCH: 1000 * 60 * 1, // 1 min
-	DOWNLOADS: Infinity, // Never invalidate
-	QUEUE: Infinity,
-	HISTORY: Infinity,
-	FAVORITES: Infinity,
-	RECENTLY_PLAYED: Infinity,
+	DOWNLOADS: 1000 * 60 * 60, // 1 hour
+	QUEUE: 1000 * 60 * 60, // 1 hour
+	HISTORY: 1000 * 60 * 60, // 1 hour
+	FAVORITES: 1000 * 60 * 60, // 1 hour
+	RECENTLY_PLAYED: 1000 * 60 * 60, // 1 hour
 } as const;
 
 // IndexedDB storage config

--- a/lib/cache/constants.ts
+++ b/lib/cache/constants.ts
@@ -33,6 +33,7 @@ export const CACHE_TIMES = {
 	SONG: 1000 * 60 * 10, // 10 min
 	ALBUM: 1000 * 60 * 10, // 10 min
 	ARTIST: 1000 * 60 * 10, // 10 min
+	PLAYLIST: 1000 * 60 * 10, // 10 min
 	SEARCH: 1000 * 60 * 1, // 1 min
 	DOWNLOADS: 1000 * 60 * 60, // 1 hour
 	QUEUE: 1000 * 60 * 60, // 1 hour

--- a/lib/config/public.ts
+++ b/lib/config/public.ts
@@ -1,30 +1,32 @@
 import { z } from "zod";
 
 function getDefaultSiteUrl() {
-  if (process.env.NEXT_PUBLIC_SITE_URL) {
-    return process.env.NEXT_PUBLIC_SITE_URL;
-  }
+	if (process.env.NEXT_PUBLIC_SITE_URL) {
+		return process.env.NEXT_PUBLIC_SITE_URL;
+	}
 
-  if (process.env.BETTER_AUTH_URL) {
-    return process.env.BETTER_AUTH_URL;
-  }
+	if (process.env.BETTER_AUTH_URL) {
+		return process.env.BETTER_AUTH_URL;
+	}
 
-  if (process.env.VERCEL_URL) {
-    return `https://${process.env.VERCEL_URL}`;
-  }
+	if (process.env.VERCEL_URL) {
+		return `https://${process.env.VERCEL_URL}`;
+	}
 
-  return "http://localhost:3000";
+	return "http://localhost:3000";
 }
 
 const publicConfigSchema = z.object({
-  NEXT_PUBLIC_API_URL: z.url(),
-  NEXT_PUBLIC_SITE_URL: z.url(),
+	NEXT_PUBLIC_API_URL: z
+		.string()
+		.url()
+		.default("https://saavn-api.nandanvarma.com/api"),
+	NEXT_PUBLIC_SITE_URL: z.string().url().default("http://localhost:3000"),
 });
 
 export const publicConfig = publicConfigSchema.parse({
-  NEXT_PUBLIC_API_URL:
-    process.env.NEXT_PUBLIC_API_URL ?? "https://saavn-api.nandanvarma.com/api",
-  NEXT_PUBLIC_SITE_URL: getDefaultSiteUrl(),
+	NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+	NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL || getDefaultSiteUrl(),
 });
 
 export const metadataBase = new URL(publicConfig.NEXT_PUBLIC_SITE_URL);

--- a/lib/config/public.ts
+++ b/lib/config/public.ts
@@ -1,30 +1,30 @@
 import { z } from "zod";
 
 function getDefaultSiteUrl() {
-	if (process.env.NEXT_PUBLIC_SITE_URL) {
-		return process.env.NEXT_PUBLIC_SITE_URL;
-	}
+  if (process.env.NEXT_PUBLIC_SITE_URL) {
+    return process.env.NEXT_PUBLIC_SITE_URL;
+  }
 
-	if (process.env.BETTER_AUTH_URL) {
-		return process.env.BETTER_AUTH_URL;
-	}
+  if (process.env.BETTER_AUTH_URL) {
+    return process.env.BETTER_AUTH_URL;
+  }
 
-	if (process.env.VERCEL_URL) {
-		return `https://${process.env.VERCEL_URL}`;
-	}
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
 
-	return "http://localhost:3000";
+  return "http://localhost:3000";
 }
 
 const publicConfigSchema = z.object({
-	NEXT_PUBLIC_API_URL: z.string().url(),
-	NEXT_PUBLIC_SITE_URL: z.string().url(),
+  NEXT_PUBLIC_API_URL: z.url(),
+  NEXT_PUBLIC_SITE_URL: z.url(),
 });
 
 export const publicConfig = publicConfigSchema.parse({
-	NEXT_PUBLIC_API_URL:
-		process.env.NEXT_PUBLIC_API_URL ?? "https://saavn-api.nandanvarma.com/api",
-	NEXT_PUBLIC_SITE_URL: getDefaultSiteUrl(),
+  NEXT_PUBLIC_API_URL:
+    process.env.NEXT_PUBLIC_API_URL ?? "https://saavn-api.nandanvarma.com/api",
+  NEXT_PUBLIC_SITE_URL: getDefaultSiteUrl(),
 });
 
 export const metadataBase = new URL(publicConfig.NEXT_PUBLIC_SITE_URL);

--- a/lib/config/server.ts
+++ b/lib/config/server.ts
@@ -2,14 +2,14 @@ import { z } from "zod";
 import { publicConfig } from "@/lib/config/public";
 
 const serverConfigSchema = z.object({
-	DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
-	BETTER_AUTH_SECRET: z.string().min(1, "BETTER_AUTH_SECRET is required"),
-	BETTER_AUTH_URL: z.string().url(),
+  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+  BETTER_AUTH_SECRET: z.string().min(1, "BETTER_AUTH_SECRET is required"),
+  BETTER_AUTH_URL: z.url(),
 });
 
 export const serverConfig = serverConfigSchema.parse({
-	DATABASE_URL: process.env.DATABASE_URL,
-	BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
-	BETTER_AUTH_URL:
-		process.env.BETTER_AUTH_URL ?? publicConfig.NEXT_PUBLIC_SITE_URL,
+  DATABASE_URL: process.env.DATABASE_URL,
+  BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
+  BETTER_AUTH_URL:
+    process.env.BETTER_AUTH_URL ?? publicConfig.NEXT_PUBLIC_SITE_URL,
 });

--- a/lib/config/server.ts
+++ b/lib/config/server.ts
@@ -2,14 +2,14 @@ import { z } from "zod";
 import { publicConfig } from "@/lib/config/public";
 
 const serverConfigSchema = z.object({
-  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
-  BETTER_AUTH_SECRET: z.string().min(1, "BETTER_AUTH_SECRET is required"),
-  BETTER_AUTH_URL: z.url(),
+	DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+	BETTER_AUTH_SECRET: z.string().min(1, "BETTER_AUTH_SECRET is required"),
+	BETTER_AUTH_URL: z.url(),
 });
 
 export const serverConfig = serverConfigSchema.parse({
-  DATABASE_URL: process.env.DATABASE_URL,
-  BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
-  BETTER_AUTH_URL:
-    process.env.BETTER_AUTH_URL ?? publicConfig.NEXT_PUBLIC_SITE_URL,
+	DATABASE_URL: process.env.DATABASE_URL,
+	BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
+	BETTER_AUTH_URL:
+		process.env.BETTER_AUTH_URL ?? publicConfig.NEXT_PUBLIC_SITE_URL,
 });

--- a/lib/queries/music.ts
+++ b/lib/queries/music.ts
@@ -21,14 +21,18 @@ export function songQueryOptions(id: string) {
 		queryKey: CACHE_KEYS.SONGS(id),
 		queryFn: () => getSongById(id),
 		staleTime: CACHE_TIMES.SONG,
+		retry: 3,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
 	});
 }
 
 export function songsQueryOptions(ids: string[]) {
 	return queryOptions({
-		queryKey: ["songs", ...ids],
+		queryKey: CACHE_KEYS.SONGS_BY_IDS(ids),
 		queryFn: () => getSongsByIds(ids),
 		staleTime: CACHE_TIMES.SONG,
+		retry: 3,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
 	});
 }
 
@@ -37,6 +41,8 @@ export function albumQueryOptions(id: string) {
 		queryKey: CACHE_KEYS.ALBUM(id),
 		queryFn: () => getAlbumById(id),
 		staleTime: CACHE_TIMES.ALBUM,
+		retry: 3,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
 	});
 }
 
@@ -45,6 +51,8 @@ export function artistQueryOptions(id: string) {
 		queryKey: CACHE_KEYS.ARTIST(id),
 		queryFn: () => getArtistById(id),
 		staleTime: CACHE_TIMES.ARTIST,
+		retry: 3,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
 	});
 }
 
@@ -53,6 +61,8 @@ export function playlistQueryOptions(id: string) {
 		queryKey: CACHE_KEYS.PLAYLIST(id),
 		queryFn: () => getPlaylistById(id),
 		staleTime: CACHE_TIMES.ALBUM,
+		retry: 3,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
 	});
 }
 
@@ -61,46 +71,58 @@ export function globalSearchQueryOptions(query: string) {
 		queryKey: CACHE_KEYS.SEARCH(query),
 		queryFn: () => searchMusic(query),
 		staleTime: CACHE_TIMES.SEARCH,
+		retry: 3,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
 	});
 }
 
 export function searchSongsQueryOptions(query: string, limit: number) {
 	return queryOptions({
-		queryKey: ["search-songs", query, limit],
+		queryKey: CACHE_KEYS.SEARCH_SONGS(query, limit),
 		queryFn: () => searchSongs(query, 0, limit),
 		staleTime: CACHE_TIMES.SEARCH,
+		retry: 3,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
 	});
 }
 
 export function searchAlbumsQueryOptions(query: string, limit: number) {
 	return queryOptions({
-		queryKey: ["search-albums", query, limit],
+		queryKey: CACHE_KEYS.SEARCH_ALBUMS(query, limit),
 		queryFn: () => searchAlbums(query, 0, limit),
 		staleTime: CACHE_TIMES.SEARCH,
+		retry: 3,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
 	});
 }
 
 export function searchArtistsQueryOptions(query: string, limit: number) {
 	return queryOptions({
-		queryKey: ["search-artists", query, limit],
+		queryKey: CACHE_KEYS.SEARCH_ARTISTS(query, limit),
 		queryFn: () => searchArtists(query, 0, limit),
 		staleTime: CACHE_TIMES.SEARCH,
+		retry: 3,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
 	});
 }
 
 export function searchPlaylistsQueryOptions(query: string, limit: number) {
 	return queryOptions({
-		queryKey: ["search-playlists", query, limit],
+		queryKey: CACHE_KEYS.SEARCH_PLAYLISTS(query, limit),
 		queryFn: () => searchPlaylists(query, 0, limit),
 		staleTime: CACHE_TIMES.SEARCH,
+		retry: 3,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
 	});
 }
 
 export function songSuggestionsQueryOptions(id: string, limit: number) {
 	return queryOptions({
-		queryKey: ["suggestions", id, limit],
+		queryKey: CACHE_KEYS.SUGGESTIONS(id, limit),
 		queryFn: () => getSongSuggestions(id, limit),
 		staleTime: CACHE_TIMES.SONG,
+		retry: 3,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
 	});
 }
 
@@ -110,9 +132,11 @@ export function artistSongsQueryOptions(
 	sortOrder: "asc" | "desc",
 ) {
 	return queryOptions({
-		queryKey: ["artist-songs", id, sortBy, sortOrder],
+		queryKey: CACHE_KEYS.ARTIST_SONGS(id, sortBy, sortOrder),
 		queryFn: () => getArtistSongs(id, 0, sortBy, sortOrder),
 		staleTime: CACHE_TIMES.ARTIST,
+		retry: 3,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
 	});
 }
 
@@ -122,8 +146,10 @@ export function artistAlbumsQueryOptions(
 	sortOrder: "asc" | "desc",
 ) {
 	return queryOptions({
-		queryKey: ["artist-albums", id, sortBy, sortOrder],
+		queryKey: CACHE_KEYS.ARTIST_ALBUMS(id, sortBy, sortOrder),
 		queryFn: () => getArtistAlbums(id, 0, sortBy, sortOrder),
 		staleTime: CACHE_TIMES.ARTIST,
+		retry: 3,
+		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
 	});
 }

--- a/lib/queries/music.ts
+++ b/lib/queries/music.ts
@@ -16,13 +16,18 @@ import {
 } from "@/lib/api";
 import { CACHE_KEYS, CACHE_TIMES } from "@/lib/cache";
 
+const DEFAULT_RETRY_CONFIG = {
+	retry: 3,
+	retryDelay: (attemptIndex: number) =>
+		Math.min(1000 * 2 ** attemptIndex, 30000),
+} as const;
+
 export function songQueryOptions(id: string) {
 	return queryOptions({
 		queryKey: CACHE_KEYS.SONGS(id),
 		queryFn: () => getSongById(id),
 		staleTime: CACHE_TIMES.SONG,
-		retry: 3,
-		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+		...DEFAULT_RETRY_CONFIG,
 	});
 }
 
@@ -31,8 +36,7 @@ export function songsQueryOptions(ids: string[]) {
 		queryKey: CACHE_KEYS.SONGS_BY_IDS(ids),
 		queryFn: () => getSongsByIds(ids),
 		staleTime: CACHE_TIMES.SONG,
-		retry: 3,
-		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+		...DEFAULT_RETRY_CONFIG,
 	});
 }
 
@@ -41,8 +45,7 @@ export function albumQueryOptions(id: string) {
 		queryKey: CACHE_KEYS.ALBUM(id),
 		queryFn: () => getAlbumById(id),
 		staleTime: CACHE_TIMES.ALBUM,
-		retry: 3,
-		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+		...DEFAULT_RETRY_CONFIG,
 	});
 }
 
@@ -51,8 +54,7 @@ export function artistQueryOptions(id: string) {
 		queryKey: CACHE_KEYS.ARTIST(id),
 		queryFn: () => getArtistById(id),
 		staleTime: CACHE_TIMES.ARTIST,
-		retry: 3,
-		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+		...DEFAULT_RETRY_CONFIG,
 	});
 }
 
@@ -60,9 +62,8 @@ export function playlistQueryOptions(id: string) {
 	return queryOptions({
 		queryKey: CACHE_KEYS.PLAYLIST(id),
 		queryFn: () => getPlaylistById(id),
-		staleTime: CACHE_TIMES.ALBUM,
-		retry: 3,
-		retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+		staleTime: CACHE_TIMES.PLAYLIST,
+		...DEFAULT_RETRY_CONFIG,
 	});
 }
 

--- a/lib/store/index.ts
+++ b/lib/store/index.ts
@@ -43,11 +43,29 @@ export const useAppStore = create<AppStore>()(
 				}
 
 				const persisted = persistedState as PersistedAppStoreState;
+				const persistedFavorites = persisted.favoriteIds ?? [];
+				const persistedDownloads = persisted.downloadedSongIds ?? [];
+
+				const currentFavorites = Array.from(currentState.favoriteIds);
+				const currentDownloads = Array.from(currentState.downloadedSongIds);
+
+				const favoritesChanged =
+					persistedFavorites.length !== currentFavorites.length ||
+					!persistedFavorites.every((id) => currentFavorites.includes(id));
+
+				const downloadsChanged =
+					persistedDownloads.length !== currentDownloads.length ||
+					!persistedDownloads.every((id) => currentDownloads.includes(id));
+
 				return {
 					...currentState,
 					...persisted,
-					favoriteIds: new Set(persisted.favoriteIds ?? []),
-					downloadedSongIds: new Set(persisted.downloadedSongIds ?? []),
+					favoriteIds: favoritesChanged
+						? new Set(persistedFavorites)
+						: currentState.favoriteIds,
+					downloadedSongIds: downloadsChanged
+						? new Set(persistedDownloads)
+						: currentState.downloadedSongIds,
 				};
 			},
 		},

--- a/lib/store/slices/downloads-slice.ts
+++ b/lib/store/slices/downloads-slice.ts
@@ -1,8 +1,4 @@
-import {
-	INITIAL_STATE,
-	type StoreGet,
-	type StoreSet,
-} from "@/lib/store/internal";
+import { type StoreGet, type StoreSet } from "@/lib/store/internal";
 import type { AppStoreActions } from "@/lib/store/types";
 
 export function createDownloadsAndUiSlice(

--- a/lib/store/slices/downloads-slice.ts
+++ b/lib/store/slices/downloads-slice.ts
@@ -46,7 +46,11 @@ export function createDownloadsAndUiSlice(
 		},
 		isDownloaded: (songId) => get().downloadedSongIds.has(songId),
 		resetStore: () => {
-			set({ ...INITIAL_STATE });
+			set({
+				isQueueOpen: false,
+				sleepTimerMinutes: null,
+				downloadedSongIds: new Set(),
+			});
 		},
 	};
 }

--- a/lib/utils/audio-error.ts
+++ b/lib/utils/audio-error.ts
@@ -45,10 +45,6 @@ export function logAudioError(
 		? {
 				code: error.code,
 				message: error.message,
-				MEDIA_ERR_ABORTED: error.MEDIA_ERR_ABORTED,
-				MEDIA_ERR_NETWORK: error.MEDIA_ERR_NETWORK,
-				DECODE: error.MEDIA_ERR_DECODE,
-				SRC_NOT_SUPPORTED: error.MEDIA_ERR_SRC_NOT_SUPPORTED,
 				context,
 				timestamp: new Date().toISOString(),
 			}

--- a/lib/utils/storage.ts
+++ b/lib/utils/storage.ts
@@ -120,7 +120,8 @@ export function isStorageAvailable(): boolean {
 		localStorage.setItem(testKey, "test");
 		localStorage.removeItem(testKey);
 		return true;
-	} catch {
+	} catch (error) {
+		logError("Storage:isAvailable", error);
 		return false;
 	}
 }
@@ -159,7 +160,8 @@ export async function hasStorageSpace(
 		const info = await getStorageInfo();
 		if (!info) return true;
 		return info.quota - info.usage > threshold;
-	} catch {
-		return true; // Assume space is available if we can't check
+	} catch (error) {
+		logError("Storage:hasSpace", error);
+		return true;
 	}
 }

--- a/lib/validations/api-schemas.ts
+++ b/lib/validations/api-schemas.ts
@@ -7,168 +7,168 @@ import { z } from "zod";
 
 // ============ BASE SCHEMAS ============
 const ImageSchema = z.object({
-  quality: z.string(),
-  url: z.url(),
+	quality: z.string(),
+	url: z.url(),
 });
 
 const ArtistMiniSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  role: z.string(),
-  type: z.string(),
-  image: z.array(ImageSchema),
-  url: z.string(),
+	id: z.string(),
+	name: z.string(),
+	role: z.string(),
+	type: z.string(),
+	image: z.array(ImageSchema),
+	url: z.string(),
 });
 
 const AlbumMiniSchema = z.object({
-  id: z.string().nullable(),
-  name: z.string().nullable(),
-  url: z.string().nullable(),
+	id: z.string().nullable(),
+	name: z.string().nullable(),
+	url: z.string().nullable(),
 });
 
 const DownloadUrlSchema = z.object({
-  quality: z.string(),
-  url: z.url(),
+	quality: z.string(),
+	url: z.url(),
 });
 
 // ============ ENTITY SCHEMAS ============
 export const DetailedSongSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  type: z.string(),
-  year: z.string().nullable(),
-  releaseDate: z.string().nullable(),
-  duration: z.number().nullable(),
-  label: z.string().nullable(),
-  explicitContent: z.boolean(),
-  playCount: z.number().nullable(),
-  language: z.string(),
-  hasLyrics: z.boolean(),
-  lyricsId: z.string().nullable(),
-  url: z.string(),
-  copyright: z.string().nullable(),
-  album: AlbumMiniSchema,
-  artists: z.object({
-    primary: z.array(ArtistMiniSchema),
-    featured: z.array(ArtistMiniSchema),
-    all: z.array(ArtistMiniSchema),
-  }),
-  image: z.array(ImageSchema),
-  downloadUrl: z.array(DownloadUrlSchema),
+	id: z.string(),
+	name: z.string(),
+	type: z.string(),
+	year: z.string().nullable(),
+	releaseDate: z.string().nullable(),
+	duration: z.number().nullable(),
+	label: z.string().nullable(),
+	explicitContent: z.boolean(),
+	playCount: z.number().nullable(),
+	language: z.string(),
+	hasLyrics: z.boolean(),
+	lyricsId: z.string().nullable(),
+	url: z.string(),
+	copyright: z.string().nullable(),
+	album: AlbumMiniSchema,
+	artists: z.object({
+		primary: z.array(ArtistMiniSchema),
+		featured: z.array(ArtistMiniSchema),
+		all: z.array(ArtistMiniSchema),
+	}),
+	image: z.array(ImageSchema),
+	downloadUrl: z.array(DownloadUrlSchema),
 });
 
 export const DetailedAlbumSchema = z.object({
-  id: z.string(),
-  title: z.string(),
-  image: z.array(ImageSchema),
-  artist: z.string(),
-  url: z.string(),
-  type: z.string(),
-  description: z.string(),
-  year: z.string(),
-  language: z.string(),
-  songs: z.array(DetailedSongSchema).optional(),
-  songIds: z.string().optional(),
+	id: z.string(),
+	title: z.string(),
+	image: z.array(ImageSchema),
+	artist: z.string(),
+	url: z.string(),
+	type: z.string(),
+	description: z.string(),
+	year: z.string(),
+	language: z.string(),
+	songs: z.array(DetailedSongSchema).optional(),
+	songIds: z.string().optional(),
 });
 
 export const DetailedArtistSchema = z.object({
-  id: z.string(),
-  title: z.string(),
-  image: z.array(ImageSchema),
-  type: z.string(),
-  description: z.string(),
-  topSongs: z.array(DetailedSongSchema).optional(),
-  topAlbums: z.array(DetailedAlbumSchema).optional(),
-  position: z.number().optional(),
+	id: z.string(),
+	title: z.string(),
+	image: z.array(ImageSchema),
+	type: z.string(),
+	description: z.string(),
+	topSongs: z.array(DetailedSongSchema).optional(),
+	topAlbums: z.array(DetailedAlbumSchema).optional(),
+	position: z.number().optional(),
 });
 
 export const DetailedPlaylistSchema = z.object({
-  id: z.string(),
-  title: z.string(),
-  image: z.array(ImageSchema),
-  url: z.string(),
-  language: z.string(),
-  type: z.string(),
-  description: z.string(),
-  songs: z.array(DetailedSongSchema).optional(),
+	id: z.string(),
+	title: z.string(),
+	image: z.array(ImageSchema),
+	url: z.string(),
+	language: z.string(),
+	type: z.string(),
+	description: z.string(),
+	songs: z.array(DetailedSongSchema).optional(),
 });
 
 // ============ SEARCH RESULT SCHEMAS ============
 export const AlbumSearchResultSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  description: z.string(),
-  url: z.string(),
-  year: z.number(),
-  type: z.string(),
-  playCount: z.number().nullable(),
-  language: z.string(),
-  explicitContent: z.boolean(),
-  artists: z.object({
-    primary: z.array(ArtistMiniSchema),
-    featured: z.array(ArtistMiniSchema),
-    all: z.array(ArtistMiniSchema),
-  }),
-  image: z.array(ImageSchema),
+	id: z.string(),
+	name: z.string(),
+	description: z.string(),
+	url: z.string(),
+	year: z.number(),
+	type: z.string(),
+	playCount: z.number().nullable(),
+	language: z.string(),
+	explicitContent: z.boolean(),
+	artists: z.object({
+		primary: z.array(ArtistMiniSchema),
+		featured: z.array(ArtistMiniSchema),
+		all: z.array(ArtistMiniSchema),
+	}),
+	image: z.array(ImageSchema),
 });
 
 export const ArtistSearchResultSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  role: z.string(),
-  image: z.array(ImageSchema),
-  type: z.string(),
-  url: z.string(),
+	id: z.string(),
+	name: z.string(),
+	role: z.string(),
+	image: z.array(ImageSchema),
+	type: z.string(),
+	url: z.string(),
 });
 
 export const PlaylistSearchResultSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  type: z.string(),
-  image: z.array(ImageSchema),
-  url: z.string(),
-  songCount: z.number(),
-  language: z.string(),
-  explicitContent: z.boolean(),
+	id: z.string(),
+	name: z.string(),
+	type: z.string(),
+	image: z.array(ImageSchema),
+	url: z.string(),
+	songCount: z.number(),
+	language: z.string(),
+	explicitContent: z.boolean(),
 });
 
 // ============ RESPONSE SCHEMAS ============
 export function createPaginatedResponseSchema<T extends z.ZodType>(
-  itemSchema: T,
+	itemSchema: T,
 ) {
-  return z.object({
-    results: z.array(itemSchema),
-    total: z.number(),
-    start: z.number(),
-    count: z.number(),
-  });
+	return z.object({
+		results: z.array(itemSchema),
+		total: z.number(),
+		start: z.number(),
+		count: z.number(),
+	});
 }
 
 export const SearchResponseSchema = z.object({
-  songs: z.object({
-    results: z.array(DetailedSongSchema),
-    total: z.number(),
-    start: z.number(),
-    count: z.number(),
-  }),
-  albums: z.object({
-    results: z.array(AlbumSearchResultSchema),
-    total: z.number(),
-    start: z.number(),
-    count: z.number(),
-  }),
-  artists: z.object({
-    results: z.array(ArtistSearchResultSchema),
-    total: z.number(),
-    start: z.number(),
-    count: z.number(),
-  }),
-  playlists: z.object({
-    results: z.array(PlaylistSearchResultSchema),
-    total: z.number(),
-    start: z.number(),
-    count: z.number(),
-  }),
+	songs: z.object({
+		results: z.array(DetailedSongSchema),
+		total: z.number(),
+		start: z.number(),
+		count: z.number(),
+	}),
+	albums: z.object({
+		results: z.array(AlbumSearchResultSchema),
+		total: z.number(),
+		start: z.number(),
+		count: z.number(),
+	}),
+	artists: z.object({
+		results: z.array(ArtistSearchResultSchema),
+		total: z.number(),
+		start: z.number(),
+		count: z.number(),
+	}),
+	playlists: z.object({
+		results: z.array(PlaylistSearchResultSchema),
+		total: z.number(),
+		start: z.number(),
+		count: z.number(),
+	}),
 });
 
 // ============ EXPORT TYPES ============

--- a/lib/validations/api-schemas.ts
+++ b/lib/validations/api-schemas.ts
@@ -7,164 +7,168 @@ import { z } from "zod";
 
 // ============ BASE SCHEMAS ============
 const ImageSchema = z.object({
-	quality: z.string(),
-	url: z.string().url(),
+  quality: z.string(),
+  url: z.url(),
 });
 
 const ArtistMiniSchema = z.object({
-	id: z.string(),
-	name: z.string(),
-	role: z.string(),
-	type: z.string(),
-	image: z.array(ImageSchema),
-	url: z.string(),
+  id: z.string(),
+  name: z.string(),
+  role: z.string(),
+  type: z.string(),
+  image: z.array(ImageSchema),
+  url: z.string(),
 });
 
 const AlbumMiniSchema = z.object({
-	id: z.string().nullable(),
-	name: z.string().nullable(),
-	url: z.string().nullable(),
+  id: z.string().nullable(),
+  name: z.string().nullable(),
+  url: z.string().nullable(),
 });
 
 const DownloadUrlSchema = z.object({
-	quality: z.string(),
-	url: z.string().url(),
+  quality: z.string(),
+  url: z.url(),
 });
 
 // ============ ENTITY SCHEMAS ============
 export const DetailedSongSchema = z.object({
-	id: z.string(),
-	name: z.string(),
-	type: z.string(),
-	year: z.string().nullable(),
-	releaseDate: z.string().nullable(),
-	duration: z.number().nullable(),
-	label: z.string().nullable(),
-	explicitContent: z.boolean(),
-	playCount: z.number().nullable(),
-	language: z.string(),
-	hasLyrics: z.boolean(),
-	lyricsId: z.string().nullable(),
-	url: z.string(),
-	copyright: z.string().nullable(),
-	album: AlbumMiniSchema,
-	artists: z.object({
-		primary: z.array(ArtistMiniSchema),
-		featured: z.array(ArtistMiniSchema),
-		all: z.array(ArtistMiniSchema),
-	}),
-	image: z.array(ImageSchema),
-	downloadUrl: z.array(DownloadUrlSchema),
+  id: z.string(),
+  name: z.string(),
+  type: z.string(),
+  year: z.string().nullable(),
+  releaseDate: z.string().nullable(),
+  duration: z.number().nullable(),
+  label: z.string().nullable(),
+  explicitContent: z.boolean(),
+  playCount: z.number().nullable(),
+  language: z.string(),
+  hasLyrics: z.boolean(),
+  lyricsId: z.string().nullable(),
+  url: z.string(),
+  copyright: z.string().nullable(),
+  album: AlbumMiniSchema,
+  artists: z.object({
+    primary: z.array(ArtistMiniSchema),
+    featured: z.array(ArtistMiniSchema),
+    all: z.array(ArtistMiniSchema),
+  }),
+  image: z.array(ImageSchema),
+  downloadUrl: z.array(DownloadUrlSchema),
 });
 
 export const DetailedAlbumSchema = z.object({
-	id: z.string(),
-	title: z.string(),
-	image: z.array(ImageSchema),
-	artist: z.string(),
-	url: z.string(),
-	type: z.string(),
-	description: z.string(),
-	year: z.string(),
-	language: z.string(),
-	songs: z.array(DetailedSongSchema).optional(),
-	songIds: z.string().optional(),
+  id: z.string(),
+  title: z.string(),
+  image: z.array(ImageSchema),
+  artist: z.string(),
+  url: z.string(),
+  type: z.string(),
+  description: z.string(),
+  year: z.string(),
+  language: z.string(),
+  songs: z.array(DetailedSongSchema).optional(),
+  songIds: z.string().optional(),
 });
 
 export const DetailedArtistSchema = z.object({
-	id: z.string(),
-	title: z.string(),
-	image: z.array(ImageSchema),
-	type: z.string(),
-	description: z.string(),
-	topSongs: z.array(DetailedSongSchema).optional(),
-	topAlbums: z.array(DetailedAlbumSchema).optional(),
-	position: z.number().optional(),
+  id: z.string(),
+  title: z.string(),
+  image: z.array(ImageSchema),
+  type: z.string(),
+  description: z.string(),
+  topSongs: z.array(DetailedSongSchema).optional(),
+  topAlbums: z.array(DetailedAlbumSchema).optional(),
+  position: z.number().optional(),
 });
 
 export const DetailedPlaylistSchema = z.object({
-	id: z.string(),
-	title: z.string(),
-	image: z.array(ImageSchema),
-	url: z.string(),
-	language: z.string(),
-	type: z.string(),
-	description: z.string(),
-	songs: z.array(DetailedSongSchema).optional(),
+  id: z.string(),
+  title: z.string(),
+  image: z.array(ImageSchema),
+  url: z.string(),
+  language: z.string(),
+  type: z.string(),
+  description: z.string(),
+  songs: z.array(DetailedSongSchema).optional(),
 });
 
 // ============ SEARCH RESULT SCHEMAS ============
 export const AlbumSearchResultSchema = z.object({
-	id: z.string(),
-	name: z.string(),
-	description: z.string(),
-	url: z.string(),
-	year: z.number(),
-	type: z.string(),
-	playCount: z.number().nullable(),
-	language: z.string(),
-	explicitContent: z.boolean(),
-	artists: z.object({
-		primary: z.array(ArtistMiniSchema),
-		featured: z.array(ArtistMiniSchema),
-		all: z.array(ArtistMiniSchema),
-	}),
-	image: z.array(ImageSchema),
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  url: z.string(),
+  year: z.number(),
+  type: z.string(),
+  playCount: z.number().nullable(),
+  language: z.string(),
+  explicitContent: z.boolean(),
+  artists: z.object({
+    primary: z.array(ArtistMiniSchema),
+    featured: z.array(ArtistMiniSchema),
+    all: z.array(ArtistMiniSchema),
+  }),
+  image: z.array(ImageSchema),
 });
 
 export const ArtistSearchResultSchema = z.object({
-	id: z.string(),
-	name: z.string(),
-	role: z.string(),
-	image: z.array(ImageSchema),
-	type: z.string(),
-	url: z.string(),
+  id: z.string(),
+  name: z.string(),
+  role: z.string(),
+  image: z.array(ImageSchema),
+  type: z.string(),
+  url: z.string(),
 });
 
 export const PlaylistSearchResultSchema = z.object({
-	id: z.string(),
-	name: z.string(),
-	type: z.string(),
-	image: z.array(ImageSchema),
-	url: z.string(),
-	songCount: z.number(),
-	language: z.string(),
-	explicitContent: z.boolean(),
+  id: z.string(),
+  name: z.string(),
+  type: z.string(),
+  image: z.array(ImageSchema),
+  url: z.string(),
+  songCount: z.number(),
+  language: z.string(),
+  explicitContent: z.boolean(),
 });
 
 // ============ RESPONSE SCHEMAS ============
-export const PaginatedResponseSchema = z.object({
-	results: z.array(z.unknown()),
-	total: z.number(),
-	start: z.number(),
-	count: z.number(),
-});
+export function createPaginatedResponseSchema<T extends z.ZodType>(
+  itemSchema: T,
+) {
+  return z.object({
+    results: z.array(itemSchema),
+    total: z.number(),
+    start: z.number(),
+    count: z.number(),
+  });
+}
 
 export const SearchResponseSchema = z.object({
-	songs: z.object({
-		results: z.array(DetailedSongSchema),
-		total: z.number(),
-		start: z.number(),
-		count: z.number(),
-	}),
-	albums: z.object({
-		results: z.array(AlbumSearchResultSchema),
-		total: z.number(),
-		start: z.number(),
-		count: z.number(),
-	}),
-	artists: z.object({
-		results: z.array(ArtistSearchResultSchema),
-		total: z.number(),
-		start: z.number(),
-		count: z.number(),
-	}),
-	playlists: z.object({
-		results: z.array(PlaylistSearchResultSchema),
-		total: z.number(),
-		start: z.number(),
-		count: z.number(),
-	}),
+  songs: z.object({
+    results: z.array(DetailedSongSchema),
+    total: z.number(),
+    start: z.number(),
+    count: z.number(),
+  }),
+  albums: z.object({
+    results: z.array(AlbumSearchResultSchema),
+    total: z.number(),
+    start: z.number(),
+    count: z.number(),
+  }),
+  artists: z.object({
+    results: z.array(ArtistSearchResultSchema),
+    total: z.number(),
+    start: z.number(),
+    count: z.number(),
+  }),
+  playlists: z.object({
+    results: z.array(PlaylistSearchResultSchema),
+    total: z.number(),
+    start: z.number(),
+    count: z.number(),
+  }),
 });
 
 // ============ EXPORT TYPES ============

--- a/lib/validations/backup.ts
+++ b/lib/validations/backup.ts
@@ -1,11 +1,24 @@
 import { z } from "zod";
+import { DetailedSongSchema } from "./entities";
+
+// Helper for JSON values
+const literalSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+type Literal = z.infer<typeof literalSchema>;
+type Json = Literal | { [key: string]: Json } | Json[];
+const jsonSchema: z.ZodType<Json> = z.lazy(() =>
+	z.union([
+		literalSchema,
+		z.array(jsonSchema),
+		z.record(z.string(), jsonSchema),
+	]),
+);
 
 export const BackupDataSchema = z.object({
 	version: z.string(),
 	timestamp: z.number(),
-	localStorage: z.record(z.string(), z.unknown()).optional(),
+	localStorage: z.record(z.string(), jsonSchema).optional(),
 	indexedDB: z
-		.record(z.string(), z.record(z.string(), z.array(z.unknown())))
+		.record(z.string(), z.record(z.string(), z.array(DetailedSongSchema)))
 		.optional(),
 });
 

--- a/lib/validations/entities.ts
+++ b/lib/validations/entities.ts
@@ -6,166 +6,166 @@
 
 import { z } from "zod";
 import {
-	ArtistRole,
-	AudioQuality,
-	EntityType,
-	ImageQuality,
-	Language,
+  ArtistRole,
+  AudioQuality,
+  EntityType,
+  ImageQuality,
+  Language,
 } from "@/types/entity";
 
 /**
  * Image schema - consistent across all entities
  */
 export const ImageSchema = z.object({
-	quality: z.nativeEnum(ImageQuality),
-	url: z.string().url(),
+  quality: z.enum(ImageQuality),
+  url: z.url(),
 });
 
 /**
  * DownloadUrl schema - audio quality and URL
  */
 export const DownloadUrlSchema = z.object({
-	quality: z.nativeEnum(AudioQuality),
-	url: z.string().url(),
+  quality: z.nativeEnum(AudioQuality),
+  url: z.url(),
 });
 
 /**
  * ArtistMini schema - minimal artist info (used in lists)
  */
 export const ArtistMiniSchema = z.object({
-	id: z.string(),
-	name: z.string(),
-	role: z.union([z.nativeEnum(ArtistRole), z.string()]),
-	type: z.union([z.nativeEnum(EntityType), z.string()]),
-	image: z.array(ImageSchema),
-	url: z.string().url(),
+  id: z.string(),
+  name: z.string(),
+  role: z.union([z.nativeEnum(ArtistRole), z.string()]),
+  type: z.union([z.nativeEnum(EntityType), z.string()]),
+  image: z.array(ImageSchema),
+  url: z.url(),
 });
 
 /**
  * AlbumMini schema - minimal album info
  */
 export const AlbumMiniSchema = z.object({
-	id: z.string().nullable(),
-	name: z.string().nullable(),
-	url: z.string().url().nullable(),
+  id: z.string().nullable(),
+  name: z.string().nullable(),
+  url: z.url().nullable(),
 });
 
 /**
  * Bio schema - artist bio information
  */
 export const BioSchema = z.object({
-	text: z.string().nullable(),
-	title: z.string().nullable(),
-	sequence: z.number().nullable(),
+  text: z.string().nullable(),
+  title: z.string().nullable(),
+  sequence: z.number().nullable(),
 });
 
 /**
  * Artists object schema (primary, featured, all)
  */
 export const ArtistsGroupSchema = z.object({
-	primary: z.array(ArtistMiniSchema),
-	featured: z.array(ArtistMiniSchema),
-	all: z.array(ArtistMiniSchema),
+  primary: z.array(ArtistMiniSchema),
+  featured: z.array(ArtistMiniSchema),
+  all: z.array(ArtistMiniSchema),
 });
 
 /**
  * DetailedSong schema - full song information with download links
  */
 export const DetailedSongSchema = z.object({
-	id: z.string(),
-	name: z.string(),
-	type: z.union([z.nativeEnum(EntityType), z.string()]),
-	year: z.string().nullable(),
-	releaseDate: z.string().nullable(),
-	duration: z.number().nullable(),
-	label: z.string().nullable(),
-	explicitContent: z.boolean(),
-	playCount: z.number().nullable(),
-	language: z.union([z.nativeEnum(Language), z.string()]),
-	hasLyrics: z.boolean(),
-	lyricsId: z.string().nullable(),
-	url: z.string().url(),
-	copyright: z.string().nullable(),
-	album: AlbumMiniSchema,
-	artists: ArtistsGroupSchema,
-	image: z.array(ImageSchema),
-	downloadUrl: z.array(DownloadUrlSchema),
+  id: z.string(),
+  name: z.string(),
+  type: z.union([z.nativeEnum(EntityType), z.string()]),
+  year: z.string().nullable(),
+  releaseDate: z.string().nullable(),
+  duration: z.number().nullable(),
+  label: z.string().nullable(),
+  explicitContent: z.boolean(),
+  playCount: z.number().nullable(),
+  language: z.union([z.nativeEnum(Language), z.string()]),
+  hasLyrics: z.boolean(),
+  lyricsId: z.string().nullable(),
+  url: z.url(),
+  copyright: z.string().nullable(),
+  album: AlbumMiniSchema,
+  artists: ArtistsGroupSchema,
+  image: z.array(ImageSchema),
+  downloadUrl: z.array(DownloadUrlSchema),
 });
 
 /**
  * DetailedAlbum schema
  */
 export const DetailedAlbumSchema = z.object({
-	id: z.string(),
-	name: z.string(),
-	description: z.string(),
-	year: z.number().nullable(),
-	type: z.union([z.nativeEnum(EntityType), z.string()]),
-	playCount: z.number().nullable(),
-	language: z.union([z.nativeEnum(Language), z.string()]),
-	explicitContent: z.boolean(),
-	artists: ArtistsGroupSchema,
-	songCount: z.number().nullable(),
-	url: z.string().url(),
-	image: z.array(ImageSchema),
-	songs: z.array(DetailedSongSchema),
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  year: z.number().nullable(),
+  type: z.union([z.nativeEnum(EntityType), z.string()]),
+  playCount: z.number().nullable(),
+  language: z.union([z.nativeEnum(Language), z.string()]),
+  explicitContent: z.boolean(),
+  artists: ArtistsGroupSchema,
+  songCount: z.number().nullable(),
+  url: z.url(),
+  image: z.array(ImageSchema),
+  songs: z.array(DetailedSongSchema),
 });
 
 /**
  * DetailedArtist schema
  */
 export const DetailedArtistSchema = z.object({
-	id: z.string(),
-	name: z.string(),
-	url: z.string().url(),
-	type: z.union([z.nativeEnum(EntityType), z.string()]),
-	image: z.array(ImageSchema),
-	followerCount: z.number().nullable(),
-	fanCount: z.string().nullable(),
-	isVerified: z.boolean().nullable(),
-	dominantLanguage: z.union([z.nativeEnum(Language), z.string()]).nullable(),
-	dominantType: z.union([z.nativeEnum(EntityType), z.string()]).nullable(),
-	bio: z.array(BioSchema).nullable(),
-	dob: z.string().nullable(),
-	fb: z.string().nullable(),
-	twitter: z.string().nullable(),
-	wiki: z.string().nullable(),
-	availableLanguages: z.array(z.string()),
-	isRadioPresent: z.boolean().nullable(),
-	topSongs: z.array(DetailedSongSchema).nullable(),
-	topAlbums: z.array(DetailedAlbumSchema).nullable(),
-	singles: z.array(DetailedSongSchema).nullable(),
-	similarArtists: z.array(ArtistMiniSchema).nullable(),
+  id: z.string(),
+  name: z.string(),
+  url: z.url(),
+  type: z.union([z.nativeEnum(EntityType), z.string()]),
+  image: z.array(ImageSchema),
+  followerCount: z.number().nullable(),
+  fanCount: z.string().nullable(),
+  isVerified: z.boolean().nullable(),
+  dominantLanguage: z.union([z.nativeEnum(Language), z.string()]).nullable(),
+  dominantType: z.union([z.nativeEnum(EntityType), z.string()]).nullable(),
+  bio: z.array(BioSchema).nullable(),
+  dob: z.string().nullable(),
+  fb: z.string().nullable(),
+  twitter: z.string().nullable(),
+  wiki: z.string().nullable(),
+  availableLanguages: z.array(z.string()),
+  isRadioPresent: z.boolean().nullable(),
+  topSongs: z.array(DetailedSongSchema).nullable(),
+  topAlbums: z.array(DetailedAlbumSchema).nullable(),
+  singles: z.array(DetailedSongSchema).nullable(),
+  similarArtists: z.array(ArtistMiniSchema).nullable(),
 });
 
 /**
  * DetailedPlaylist schema
  */
 export const DetailedPlaylistSchema = z.object({
-	id: z.string(),
-	name: z.string(),
-	description: z.string(),
-	year: z.number().nullable(),
-	type: z.union([z.nativeEnum(EntityType), z.string()]),
-	playCount: z.number().nullable(),
-	language: z.union([z.nativeEnum(Language), z.string()]),
-	explicitContent: z.boolean(),
-	songCount: z.number().nullable(),
-	url: z.string().url(),
-	image: z.array(ImageSchema),
-	songs: z.array(DetailedSongSchema),
-	artists: z.array(ArtistMiniSchema),
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  year: z.number().nullable(),
+  type: z.union([z.nativeEnum(EntityType), z.string()]),
+  playCount: z.number().nullable(),
+  language: z.union([z.nativeEnum(Language), z.string()]),
+  explicitContent: z.boolean(),
+  songCount: z.number().nullable(),
+  url: z.url(),
+  image: z.array(ImageSchema),
+  songs: z.array(DetailedSongSchema),
+  artists: z.array(ArtistMiniSchema),
 });
 
 /**
  * LocalPlaylist schema - user-created playlists
  */
 export const LocalPlaylistSchema = z.object({
-	id: z.string(),
-	name: z.string().min(1, "Playlist name cannot be empty"),
-	songs: z.array(DetailedSongSchema),
-	createdAt: z.number(),
-	updatedAt: z.number(),
+  id: z.string(),
+  name: z.string().min(1, "Playlist name cannot be empty"),
+  songs: z.array(DetailedSongSchema),
+  createdAt: z.number(),
+  updatedAt: z.number(),
 });
 
 /**
@@ -175,62 +175,66 @@ export const LocalPlaylistSchema = z.object({
 /**
  * Paginated response schema for search results
  */
-export const PaginatedResponseSchema = z.object({
-	results: z.array(z.unknown()), // Results array, type depends on context
-	total: z.number(),
-	start: z.number(),
-	count: z.number(),
-});
+export function createPaginatedResponseSchema<T extends z.ZodTypeAny>(
+  itemSchema: T,
+) {
+  return z.object({
+    results: z.array(itemSchema), // Results array, type depends on context
+    total: z.number(),
+    start: z.number(),
+    count: z.number(),
+  });
+}
 
 /**
  * Search response schema
  */
 export const SearchResponseSchema = z.object({
-	songs: z.object({
-		results: z.array(DetailedSongSchema),
-		position: z.number(),
-	}),
-	albums: z.object({
-		results: z.array(
-			z.object({
-				id: z.string(),
-				name: z.string(),
-				description: z.string().optional(),
-				url: z.string(),
-				year: z.number(),
-				type: z.union([z.nativeEnum(EntityType), z.string()]),
-				artists: ArtistsGroupSchema.optional(),
-				image: z.array(ImageSchema),
-			}),
-		),
-		position: z.number(),
-	}),
-	artists: z.object({
-		results: z.array(
-			z.object({
-				id: z.string(),
-				name: z.string(),
-				url: z.string(),
-				image: z.array(ImageSchema),
-				type: z.union([z.nativeEnum(EntityType), z.string()]),
-			}),
-		),
-		position: z.number(),
-	}),
-	playlists: z.object({
-		results: z.array(
-			z.object({
-				id: z.string(),
-				name: z.string(),
-				type: z.union([z.nativeEnum(EntityType), z.string()]),
-				image: z.array(ImageSchema),
-				url: z.string(),
-				songCount: z.number(),
-				language: z.union([z.nativeEnum(Language), z.string()]),
-			}),
-		),
-		position: z.number(),
-	}),
+  songs: z.object({
+    results: z.array(DetailedSongSchema),
+    position: z.number(),
+  }),
+  albums: z.object({
+    results: z.array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        description: z.string().optional(),
+        url: z.string(),
+        year: z.number(),
+        type: z.union([z.nativeEnum(EntityType), z.string()]),
+        artists: ArtistsGroupSchema.optional(),
+        image: z.array(ImageSchema),
+      }),
+    ),
+    position: z.number(),
+  }),
+  artists: z.object({
+    results: z.array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        url: z.string(),
+        image: z.array(ImageSchema),
+        type: z.union([z.nativeEnum(EntityType), z.string()]),
+      }),
+    ),
+    position: z.number(),
+  }),
+  playlists: z.object({
+    results: z.array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        type: z.union([z.nativeEnum(EntityType), z.string()]),
+        image: z.array(ImageSchema),
+        url: z.string(),
+        songCount: z.number(),
+        language: z.union([z.nativeEnum(Language), z.string()]),
+      }),
+    ),
+    position: z.number(),
+  }),
 });
 
 /**
@@ -251,9 +255,9 @@ export type SearchResponse = z.infer<typeof SearchResponseSchema>;
  * Safe parse wrapper - returns data or null on validation failure
  */
 export function parseEntity<T>(
-	schema: z.ZodSchema<T>,
-	data: unknown,
+  schema: z.ZodSchema<T>,
+  data: unknown,
 ): T | null {
-	const result = schema.safeParse(data);
-	return result.success ? result.data : null;
+  const result = schema.safeParse(data);
+  return result.success ? result.data : null;
 }

--- a/lib/validations/entities.ts
+++ b/lib/validations/entities.ts
@@ -6,166 +6,166 @@
 
 import { z } from "zod";
 import {
-  ArtistRole,
-  AudioQuality,
-  EntityType,
-  ImageQuality,
-  Language,
+	ArtistRole,
+	AudioQuality,
+	EntityType,
+	ImageQuality,
+	Language,
 } from "@/types/entity";
 
 /**
  * Image schema - consistent across all entities
  */
 export const ImageSchema = z.object({
-  quality: z.enum(ImageQuality),
-  url: z.url(),
+	quality: z.enum(ImageQuality),
+	url: z.url(),
 });
 
 /**
  * DownloadUrl schema - audio quality and URL
  */
 export const DownloadUrlSchema = z.object({
-  quality: z.nativeEnum(AudioQuality),
-  url: z.url(),
+	quality: z.nativeEnum(AudioQuality),
+	url: z.url(),
 });
 
 /**
  * ArtistMini schema - minimal artist info (used in lists)
  */
 export const ArtistMiniSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  role: z.union([z.nativeEnum(ArtistRole), z.string()]),
-  type: z.union([z.nativeEnum(EntityType), z.string()]),
-  image: z.array(ImageSchema),
-  url: z.url(),
+	id: z.string(),
+	name: z.string(),
+	role: z.union([z.nativeEnum(ArtistRole), z.string()]),
+	type: z.union([z.nativeEnum(EntityType), z.string()]),
+	image: z.array(ImageSchema),
+	url: z.url(),
 });
 
 /**
  * AlbumMini schema - minimal album info
  */
 export const AlbumMiniSchema = z.object({
-  id: z.string().nullable(),
-  name: z.string().nullable(),
-  url: z.url().nullable(),
+	id: z.string().nullable(),
+	name: z.string().nullable(),
+	url: z.url().nullable(),
 });
 
 /**
  * Bio schema - artist bio information
  */
 export const BioSchema = z.object({
-  text: z.string().nullable(),
-  title: z.string().nullable(),
-  sequence: z.number().nullable(),
+	text: z.string().nullable(),
+	title: z.string().nullable(),
+	sequence: z.number().nullable(),
 });
 
 /**
  * Artists object schema (primary, featured, all)
  */
 export const ArtistsGroupSchema = z.object({
-  primary: z.array(ArtistMiniSchema),
-  featured: z.array(ArtistMiniSchema),
-  all: z.array(ArtistMiniSchema),
+	primary: z.array(ArtistMiniSchema),
+	featured: z.array(ArtistMiniSchema),
+	all: z.array(ArtistMiniSchema),
 });
 
 /**
  * DetailedSong schema - full song information with download links
  */
 export const DetailedSongSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  type: z.union([z.nativeEnum(EntityType), z.string()]),
-  year: z.string().nullable(),
-  releaseDate: z.string().nullable(),
-  duration: z.number().nullable(),
-  label: z.string().nullable(),
-  explicitContent: z.boolean(),
-  playCount: z.number().nullable(),
-  language: z.union([z.nativeEnum(Language), z.string()]),
-  hasLyrics: z.boolean(),
-  lyricsId: z.string().nullable(),
-  url: z.url(),
-  copyright: z.string().nullable(),
-  album: AlbumMiniSchema,
-  artists: ArtistsGroupSchema,
-  image: z.array(ImageSchema),
-  downloadUrl: z.array(DownloadUrlSchema),
+	id: z.string(),
+	name: z.string(),
+	type: z.union([z.nativeEnum(EntityType), z.string()]),
+	year: z.string().nullable(),
+	releaseDate: z.string().nullable(),
+	duration: z.number().nullable(),
+	label: z.string().nullable(),
+	explicitContent: z.boolean(),
+	playCount: z.number().nullable(),
+	language: z.union([z.nativeEnum(Language), z.string()]),
+	hasLyrics: z.boolean(),
+	lyricsId: z.string().nullable(),
+	url: z.url(),
+	copyright: z.string().nullable(),
+	album: AlbumMiniSchema,
+	artists: ArtistsGroupSchema,
+	image: z.array(ImageSchema),
+	downloadUrl: z.array(DownloadUrlSchema),
 });
 
 /**
  * DetailedAlbum schema
  */
 export const DetailedAlbumSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  description: z.string(),
-  year: z.number().nullable(),
-  type: z.union([z.nativeEnum(EntityType), z.string()]),
-  playCount: z.number().nullable(),
-  language: z.union([z.nativeEnum(Language), z.string()]),
-  explicitContent: z.boolean(),
-  artists: ArtistsGroupSchema,
-  songCount: z.number().nullable(),
-  url: z.url(),
-  image: z.array(ImageSchema),
-  songs: z.array(DetailedSongSchema),
+	id: z.string(),
+	name: z.string(),
+	description: z.string(),
+	year: z.number().nullable(),
+	type: z.union([z.nativeEnum(EntityType), z.string()]),
+	playCount: z.number().nullable(),
+	language: z.union([z.nativeEnum(Language), z.string()]),
+	explicitContent: z.boolean(),
+	artists: ArtistsGroupSchema,
+	songCount: z.number().nullable(),
+	url: z.url(),
+	image: z.array(ImageSchema),
+	songs: z.array(DetailedSongSchema),
 });
 
 /**
  * DetailedArtist schema
  */
 export const DetailedArtistSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  url: z.url(),
-  type: z.union([z.nativeEnum(EntityType), z.string()]),
-  image: z.array(ImageSchema),
-  followerCount: z.number().nullable(),
-  fanCount: z.string().nullable(),
-  isVerified: z.boolean().nullable(),
-  dominantLanguage: z.union([z.nativeEnum(Language), z.string()]).nullable(),
-  dominantType: z.union([z.nativeEnum(EntityType), z.string()]).nullable(),
-  bio: z.array(BioSchema).nullable(),
-  dob: z.string().nullable(),
-  fb: z.string().nullable(),
-  twitter: z.string().nullable(),
-  wiki: z.string().nullable(),
-  availableLanguages: z.array(z.string()),
-  isRadioPresent: z.boolean().nullable(),
-  topSongs: z.array(DetailedSongSchema).nullable(),
-  topAlbums: z.array(DetailedAlbumSchema).nullable(),
-  singles: z.array(DetailedSongSchema).nullable(),
-  similarArtists: z.array(ArtistMiniSchema).nullable(),
+	id: z.string(),
+	name: z.string(),
+	url: z.url(),
+	type: z.union([z.nativeEnum(EntityType), z.string()]),
+	image: z.array(ImageSchema),
+	followerCount: z.number().nullable(),
+	fanCount: z.string().nullable(),
+	isVerified: z.boolean().nullable(),
+	dominantLanguage: z.union([z.nativeEnum(Language), z.string()]).nullable(),
+	dominantType: z.union([z.nativeEnum(EntityType), z.string()]).nullable(),
+	bio: z.array(BioSchema).nullable(),
+	dob: z.string().nullable(),
+	fb: z.string().nullable(),
+	twitter: z.string().nullable(),
+	wiki: z.string().nullable(),
+	availableLanguages: z.array(z.string()),
+	isRadioPresent: z.boolean().nullable(),
+	topSongs: z.array(DetailedSongSchema).nullable(),
+	topAlbums: z.array(DetailedAlbumSchema).nullable(),
+	singles: z.array(DetailedSongSchema).nullable(),
+	similarArtists: z.array(ArtistMiniSchema).nullable(),
 });
 
 /**
  * DetailedPlaylist schema
  */
 export const DetailedPlaylistSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  description: z.string(),
-  year: z.number().nullable(),
-  type: z.union([z.nativeEnum(EntityType), z.string()]),
-  playCount: z.number().nullable(),
-  language: z.union([z.nativeEnum(Language), z.string()]),
-  explicitContent: z.boolean(),
-  songCount: z.number().nullable(),
-  url: z.url(),
-  image: z.array(ImageSchema),
-  songs: z.array(DetailedSongSchema),
-  artists: z.array(ArtistMiniSchema),
+	id: z.string(),
+	name: z.string(),
+	description: z.string(),
+	year: z.number().nullable(),
+	type: z.union([z.nativeEnum(EntityType), z.string()]),
+	playCount: z.number().nullable(),
+	language: z.union([z.nativeEnum(Language), z.string()]),
+	explicitContent: z.boolean(),
+	songCount: z.number().nullable(),
+	url: z.url(),
+	image: z.array(ImageSchema),
+	songs: z.array(DetailedSongSchema),
+	artists: z.array(ArtistMiniSchema),
 });
 
 /**
  * LocalPlaylist schema - user-created playlists
  */
 export const LocalPlaylistSchema = z.object({
-  id: z.string(),
-  name: z.string().min(1, "Playlist name cannot be empty"),
-  songs: z.array(DetailedSongSchema),
-  createdAt: z.number(),
-  updatedAt: z.number(),
+	id: z.string(),
+	name: z.string().min(1, "Playlist name cannot be empty"),
+	songs: z.array(DetailedSongSchema),
+	createdAt: z.number(),
+	updatedAt: z.number(),
 });
 
 /**
@@ -176,65 +176,65 @@ export const LocalPlaylistSchema = z.object({
  * Paginated response schema for search results
  */
 export function createPaginatedResponseSchema<T extends z.ZodTypeAny>(
-  itemSchema: T,
+	itemSchema: T,
 ) {
-  return z.object({
-    results: z.array(itemSchema), // Results array, type depends on context
-    total: z.number(),
-    start: z.number(),
-    count: z.number(),
-  });
+	return z.object({
+		results: z.array(itemSchema), // Results array, type depends on context
+		total: z.number(),
+		start: z.number(),
+		count: z.number(),
+	});
 }
 
 /**
  * Search response schema
  */
 export const SearchResponseSchema = z.object({
-  songs: z.object({
-    results: z.array(DetailedSongSchema),
-    position: z.number(),
-  }),
-  albums: z.object({
-    results: z.array(
-      z.object({
-        id: z.string(),
-        name: z.string(),
-        description: z.string().optional(),
-        url: z.string(),
-        year: z.number(),
-        type: z.union([z.nativeEnum(EntityType), z.string()]),
-        artists: ArtistsGroupSchema.optional(),
-        image: z.array(ImageSchema),
-      }),
-    ),
-    position: z.number(),
-  }),
-  artists: z.object({
-    results: z.array(
-      z.object({
-        id: z.string(),
-        name: z.string(),
-        url: z.string(),
-        image: z.array(ImageSchema),
-        type: z.union([z.nativeEnum(EntityType), z.string()]),
-      }),
-    ),
-    position: z.number(),
-  }),
-  playlists: z.object({
-    results: z.array(
-      z.object({
-        id: z.string(),
-        name: z.string(),
-        type: z.union([z.nativeEnum(EntityType), z.string()]),
-        image: z.array(ImageSchema),
-        url: z.string(),
-        songCount: z.number(),
-        language: z.union([z.nativeEnum(Language), z.string()]),
-      }),
-    ),
-    position: z.number(),
-  }),
+	songs: z.object({
+		results: z.array(DetailedSongSchema),
+		position: z.number(),
+	}),
+	albums: z.object({
+		results: z.array(
+			z.object({
+				id: z.string(),
+				name: z.string(),
+				description: z.string().optional(),
+				url: z.string(),
+				year: z.number(),
+				type: z.union([z.nativeEnum(EntityType), z.string()]),
+				artists: ArtistsGroupSchema.optional(),
+				image: z.array(ImageSchema),
+			}),
+		),
+		position: z.number(),
+	}),
+	artists: z.object({
+		results: z.array(
+			z.object({
+				id: z.string(),
+				name: z.string(),
+				url: z.string(),
+				image: z.array(ImageSchema),
+				type: z.union([z.nativeEnum(EntityType), z.string()]),
+			}),
+		),
+		position: z.number(),
+	}),
+	playlists: z.object({
+		results: z.array(
+			z.object({
+				id: z.string(),
+				name: z.string(),
+				type: z.union([z.nativeEnum(EntityType), z.string()]),
+				image: z.array(ImageSchema),
+				url: z.string(),
+				songCount: z.number(),
+				language: z.union([z.nativeEnum(Language), z.string()]),
+			}),
+		),
+		position: z.number(),
+	}),
 });
 
 /**
@@ -255,9 +255,9 @@ export type SearchResponse = z.infer<typeof SearchResponseSchema>;
  * Safe parse wrapper - returns data or null on validation failure
  */
 export function parseEntity<T>(
-  schema: z.ZodSchema<T>,
-  data: unknown,
+	schema: z.ZodSchema<T>,
+	data: unknown,
 ): T | null {
-  const result = schema.safeParse(data);
-  return result.success ? result.data : null;
+	const result = schema.safeParse(data);
+	return result.success ? result.data : null;
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"format": "biome format",
 		"test": "vitest",
 		"test:coverage": "vitest --coverage",
+		"clean": "rm -rf .next coverage",
 		"analyze": "node ./scripts/generate-build-info.mjs && ANALYZE=true next build --webpack",
 		"analyze:turbopack": "node ./scripts/generate-build-info.mjs && next experimental-analyze"
 	},

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
 		"start": "next start",
 		"lint": "biome check",
 		"format": "biome format",
+		"test": "vitest",
+		"test:coverage": "vitest --coverage",
 		"analyze": "node ./scripts/generate-build-info.mjs && ANALYZE=true next build --webpack",
 		"analyze:turbopack": "node ./scripts/generate-build-info.mjs && next experimental-analyze"
 	},
@@ -80,10 +82,12 @@
 		"@types/node": "^25.5.0",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
+		"@vitest/coverage-v8": "4.1.2",
 		"drizzle-kit": "0.31.10",
 		"tailwindcss": "^4.2.2",
 		"tw-animate-css": "^1.4.0",
 		"typescript": "^5.9.3",
+		"vitest": "4.1.2",
 		"webpack-bundle-analyzer": "^5.2.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,7 +112,7 @@ importers:
         version: 1.2.3
       better-auth:
         specifier: 1.5.5
-        version: 1.5.5(drizzle-kit@0.31.10)(drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@types/pg@8.18.0)(kysely@0.28.12))(mongodb@7.1.0)(next@16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 1.5.5(drizzle-kit@0.31.10)(drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@types/pg@8.18.0)(kysely@0.28.12))(mongodb@7.1.0)(next@16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -207,6 +207,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@vitest/coverage-v8':
+        specifier: 4.1.2
+        version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)))
       drizzle-kit:
         specifier: 0.31.10
         version: 0.31.10
@@ -219,6 +222,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: 4.1.2
+        version: 4.1.2(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))
       webpack-bundle-analyzer:
         specifier: ^5.2.0
         version: 5.2.0
@@ -228,6 +234,27 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@better-auth/core@1.5.5':
     resolution: {integrity: sha512-1oR/2jAp821Dcf67kQYHUoyNcdc1TcShfw4QMK0YTVntuRES5mUOyvEJql5T6eIuLfaqaN4LOF78l0FtF66HXA==}
@@ -386,8 +413,14 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
   '@emnapi/runtime@1.9.0':
     resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -1033,6 +1066,12 @@ packages:
   '@mongodb-js/saslprep@1.4.6':
     resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
 
+  '@napi-rs/wasm-runtime@1.1.2':
+    resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@neondatabase/serverless@1.0.2':
     resolution: {integrity: sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==}
     engines: {node: '>=19.0.0'}
@@ -1102,6 +1141,9 @@ packages:
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
     engines: {node: '>= 20.19.0'}
+
+  '@oxc-project/types@0.122.0':
+    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -1749,6 +1791,104 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.12':
+    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
+
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -1883,6 +2023,18 @@ packages:
   '@tanstack/virtual-core@3.13.23':
     resolution: {integrity: sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==}
 
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/he@1.2.3':
     resolution: {integrity: sha512-q67/qwlxblDzEDvzHhVkwc1gzVWxaNxeyHUBF4xElrvjL11O+Ytze+1fGpBHlr/H9myiBUaUXNnNPmBHxxfAcA==}
 
@@ -1909,6 +2061,44 @@ packages:
   '@types/whatwg-url@13.0.0':
     resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
 
+  '@vitest/coverage-v8@4.1.2':
+    resolution: {integrity: sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==}
+    peerDependencies:
+      '@vitest/browser': 4.1.2
+      vitest: 4.1.2
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.2':
+    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+
+  '@vitest/mocker@4.1.2':
+    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.2':
+    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+
+  '@vitest/runner@4.1.2':
+    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+
+  '@vitest/snapshot@4.1.2':
+    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+
+  '@vitest/spy@4.1.2':
+    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+
+  '@vitest/utils@4.1.2':
+    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
+
   acorn-walk@8.3.5:
     resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
@@ -1921,6 +2111,13 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   baseline-browser-mapping@2.10.8:
     resolution: {integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==}
@@ -2007,6 +2204,10 @@ packages:
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -2026,6 +2227,9 @@ packages:
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -2165,6 +2369,9 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
     engines: {node: '>=12'}
@@ -2183,6 +2390,22 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   framer-motion@12.38.0:
     resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
@@ -2217,6 +2440,10 @@ packages:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
     engines: {node: '>=10'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
@@ -2237,12 +2464,27 @@ packages:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   kysely@0.28.12:
     resolution: {integrity: sha512-kWiueDWXhbCchgiotwXkwdxZE/6h56IHAeFWg4euUfW0YsmO9sxbAxzx1KLLv2lox15EfuuxHQvgJ1qIfZuHGw==}
@@ -2329,6 +2571,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
@@ -2445,9 +2694,15 @@ packages:
       react-router-dom:
         optional: true
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   opener@1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -2462,6 +2717,10 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -2551,6 +2810,11 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  rolldown@1.0.0-rc.12:
+    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
 
@@ -2568,6 +2832,9 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   sirv@2.0.4:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
@@ -2597,6 +2864,12 @@ packages:
   sparse-bitfield@3.0.3:
     resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -2610,6 +2883,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
@@ -2619,6 +2896,21 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -2681,6 +2973,84 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
+  vite@8.0.3:
+    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.2:
+    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.2
+      '@vitest/browser-preview': 4.1.2
+      '@vitest/browser-webdriverio': 4.1.2
+      '@vitest/ui': 4.1.2
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -2698,6 +3068,11 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   ws@7.5.10:
     resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
@@ -2751,6 +3126,21 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.12)(nanostores@1.2.0)':
     dependencies:
@@ -2868,7 +3258,18 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.9.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -3247,6 +3648,13 @@ snapshots:
     dependencies:
       sparse-bitfield: 3.0.3
 
+  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@neondatabase/serverless@1.0.2':
     dependencies:
       '@types/node': 22.19.15
@@ -3288,6 +3696,8 @@ snapshots:
   '@noble/ciphers@2.1.1': {}
 
   '@noble/hashes@2.0.1': {}
+
+  '@oxc-project/types@0.122.0': {}
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -3966,6 +4376,58 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.12': {}
+
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -4070,6 +4532,20 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.23': {}
 
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
   '@types/he@1.2.3': {}
 
   '@types/node@22.19.15':
@@ -4100,6 +4576,61 @@ snapshots:
     dependencies:
       '@types/webidl-conversions': 7.0.3
 
+  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.2
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.2(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))
+
+  '@vitest/expect@4.1.2':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.2':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.2':
+    dependencies:
+      '@vitest/utils': 4.1.2
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/utils': 4.1.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.2': {}
+
+  '@vitest/utils@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
@@ -4110,9 +4641,17 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
   baseline-browser-mapping@2.10.8: {}
 
-  better-auth@1.5.5(drizzle-kit@0.31.10)(drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@types/pg@8.18.0)(kysely@0.28.12))(mongodb@7.1.0)(next@16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  better-auth@1.5.5(drizzle-kit@0.31.10)(drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@types/pg@8.18.0)(kysely@0.28.12))(mongodb@7.1.0)(next@16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))):
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@neondatabase/serverless@1.0.2)(@types/pg@8.18.0)(kysely@0.28.12))
@@ -4138,6 +4677,7 @@ snapshots:
       next: 16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+      vitest: 4.1.2(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
 
@@ -4155,6 +4695,8 @@ snapshots:
   buffer-from@1.1.2: {}
 
   caniuse-lite@1.0.30001780: {}
+
+  chai@6.2.2: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -4177,6 +4719,8 @@ snapshots:
       - '@types/react-dom'
 
   commander@7.2.0: {}
+
+  convert-source-map@2.0.0: {}
 
   csstype@3.2.3: {}
 
@@ -4223,6 +4767,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  es-module-lexer@2.0.0: {}
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -4309,6 +4855,16 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   framer-motion@12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       motion-dom: 12.38.0
@@ -4333,6 +4889,8 @@ snapshots:
     dependencies:
       duplexer: 0.1.2
 
+  has-flag@4.0.0: {}
+
   he@1.2.0: {}
 
   html-escaper@2.0.2: {}
@@ -4346,9 +4904,24 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.6.1: {}
 
   jose@6.2.2: {}
+
+  js-tokens@10.0.0: {}
 
   kysely@0.28.12: {}
 
@@ -4408,6 +4981,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   memory-pager@1.5.0: {}
 
@@ -4478,7 +5061,11 @@ snapshots:
     optionalDependencies:
       next: 16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
+  obug@2.1.1: {}
+
   opener@1.5.2: {}
+
+  pathe@2.0.3: {}
 
   pg-int8@1.0.1: {}
 
@@ -4493,6 +5080,8 @@ snapshots:
       postgres-interval: 1.2.0
 
   picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
 
   postcss@8.4.31:
     dependencies:
@@ -4571,12 +5160,35 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0):
+    dependencies:
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.12
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   rou3@0.7.12: {}
 
   scheduler@0.27.0: {}
 
-  semver@7.7.4:
-    optional: true
+  semver@7.7.4: {}
 
   set-cookie-parser@3.0.1: {}
 
@@ -4612,6 +5224,8 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  siginfo@2.0.0: {}
+
   sirv@2.0.4:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -4642,16 +5256,35 @@ snapshots:
     dependencies:
       memory-pager: 1.5.0
 
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
+
   styled-jsx@5.1.6(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.2: {}
 
   tapable@2.3.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.4: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   totalist@3.0.1: {}
 
@@ -4704,6 +5337,50 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.5.0
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+    transitivePeerDependencies:
+      - msw
+
   webidl-conversions@7.0.0: {}
 
   webpack-bundle-analyzer@4.10.1:
@@ -4746,6 +5423,11 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   ws@7.5.10: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		globals: true,
+		include: ["__tests__/**/*.test.ts"],
+	},
+	resolve: {
+		alias: {
+			"@": path.resolve(__dirname, "."),
+		},
+	},
+});


### PR DESCRIPTION
## Summary
- Add test fixtures in `__tests__/fixtures/` with typed factory functions for entities
- Create store test utilities for Zustand slice testing
- Simplify React Query type handling in hooks
- Various bug fixes and improvements from previous commits

## Changes
- Test fixtures: `createDetailedSong()`, `createAlbumMini()`, `createArtistMini()`, etc.
- Store utilities: `createMockStore()`, `createMockState()`
- Query hooks with cleaner generics

## Testing
- Build: pass
- Tests: 418 passed